### PR TITLE
Compacts Google Analytics events for MetroExtracts

### DIFF
--- a/src/scripts/datapages.js
+++ b/src/scripts/datapages.js
@@ -95,7 +95,7 @@ $('body').on('click', 'a.metro-format', function () {
   var $this = $(this)
   var name = $this.data('name')
   var format = $this.data('format')
-  ga('send', 'event', name, 'click', format)
+  ga('send', 'event', 'metroextracts', name, format)
 })
 
 // Highlights a place on the map when the name is clicked


### PR DESCRIPTION
Reorders Google Anaytics events for MetroExtracts page.

Previously: Events were organized primarily by country, so MetroExtracts events crowded out all other types of events, with the nondescriptive action `click`.

Now: All MetroExtracts are organized into a category `metroextracts`, with a descriptive action of `extract_name`.

Analyzing historical data will require joining the previous category name with action names after the changeover.

# Additional Actions
- [ ] Create dated note in Google Analytics when this is merged documenting the break to allow historical analysis

# Connections
- Fixes #4 
- Part of / connected to mapzen/developer#427