### PR TITLE
show encompassing metros on a new extract

### DIFF
--- a/App/static/index.html
+++ b/App/static/index.html
@@ -197,6 +197,8 @@
         return false
       }
     }
+
+    var extractLayers = [];
     function initDisplayMap (geoJSONUrl, geoJSONOptions) {
       var southwest = L.latLng(0, -125)
       var northeast = L.latLng(0, 125)
@@ -226,7 +228,7 @@
         url: geoJSONUrl,
         dataType: 'json',
         success: function (data) {
-          L.geoJson(data, geoJSONOptions).addTo(displayMap)
+          L.geoJson(data, geoJSONOptions).addTo(displayMap);
         },
         error: function (request, status, error) {
           // do nothing
@@ -240,9 +242,9 @@
     var getNormalizedId = function (name) {
       return name.toLowerCase().replace(/,?\s+/g, '-').replace(/_/g, '-')
     }
-    var markers = {}
 
     var onEachFeature = function (feature, layer) {
+      extractLayers.push(layer);
       if (feature.properties && feature.properties.name) {
         var text = feature.properties.name;
         layer.on('click', function (e) {
@@ -334,7 +336,8 @@
       
       d3.json("https://search.mapzen.com/v1/search?text="+query+"&sources=wof&api_key=search-owZDPeC", function(error, json) {
           var bbox = json.features[0].bbox;
-          displayMap.fitBounds([[bbox[1],bbox[0]],[bbox[3], bbox[2]]])
+          displayMap.fitBounds([[bbox[1],bbox[0]],[bbox[3], bbox[2]]]);
+
           if (json.features[0].properties.layer == "locality") displayMap.zoomOut(2);
           if (d3.selectAll(".city")[0].length == 0){
             requestExtract(json.features[0]);
@@ -390,10 +393,16 @@
         displayMap.addLayer(outline);
       });
 
-      //Polygon.getBounds().contains(MarketLatLng);
-      /* to do: 
-        check to see if the bounding box is contained by an existing extract
-      */
+      var bbox = metro.bbox,
+        p1 = L.latLng(bbox[1],bbox[0]),
+        p2 = L.latLng(bbox[3],bbox[2]),
+        p3 = L.latLng(bbox[1],bbox[2]),
+        p4 = L.latLng(bbox[3],bbox[0]);
+        
+      extractLayers.forEach(function(l){
+        if (l.getBounds().contains(p1) || l.getBounds().contains(p2) || l.getBounds().contains(p3) || l.getBounds().contains(p4)) 
+          console.log(l.feature.properties.name)
+      });
 
       d3.select("#make-request").style("display","block")
         .selectAll(".name").text(metro.properties.name);

--- a/App/static/index.html
+++ b/App/static/index.html
@@ -94,6 +94,9 @@
         background: rgba(110,160,164,.3);
         padding: 20px;
       }
+      #make-request .btn {
+        margin-bottom: 20px;
+      }
       #make-request .btn:hover {
         background: rgba(110,160,164,.4);
       }
@@ -166,11 +169,12 @@
         <input id='search_submit' type="submit" value="search" class="col-xs-4 col-sm-3 btn btn-transparent">
         <div class="autocomplete"></div>
       </div>
-      <div id='extracts'></div>
       <div id="make-request">
         <p>Hmm, we don't have an extract for <span class="name"></span> yet. Would you like to request one?</p>
         <a class="btn btn-transparent" target="_blank">Create <span class="name"></span> Request</a>
+        <p>Otherwise, would one of these work?</p>
       </div>
+      <div id='extracts'></div>
       <div class='row' id='request'>
         <p>Can't find what you're looking for? Request one!</p>
         <div class='btn btn-transparent'>Submit GH Issue</div>
@@ -280,6 +284,7 @@
         .entries(cityArray)
         .sort(function(a,b){ return (a.key < b.key) ? -1 : (a.key > b.key) ? 1 : 0; });
 
+      console.log(nestedCities);
       drawList(nestedCities);
     });
 
@@ -398,11 +403,22 @@
         p2 = L.latLng(bbox[3],bbox[2]),
         p3 = L.latLng(bbox[1],bbox[2]),
         p4 = L.latLng(bbox[3],bbox[0]);
-        
+
+      var nearby = [{
+        key : "Nearby Cities",
+        values : []
+      }];
+
       extractLayers.forEach(function(l){
         if (l.getBounds().contains(p1) || l.getBounds().contains(p2) || l.getBounds().contains(p3) || l.getBounds().contains(p4)) 
-          console.log(l.feature.properties.name)
+          nearby[0].values.push({
+            city : l.feature.properties.name.split("_")[0],
+            country : l.feature.properties.name.split("_")[1],
+            bbox : l.feature.bbox
+          })
       });
+      console.log(nearby)
+      drawList(nearby);
 
       d3.select("#make-request").style("display","block")
         .selectAll(".name").text(metro.properties.name);

--- a/App/static/index.html
+++ b/App/static/index.html
@@ -94,11 +94,11 @@
         background: rgba(110,160,164,.3);
         padding: 20px;
       }
-      #make-request .btn {
-        margin-bottom: 20px;
-      }
       #make-request .btn:hover {
         background: rgba(110,160,164,.4);
+      }
+      .nearby-text {
+        display: none;
       }
       #request {
         background: rgb(224,224,224);
@@ -172,8 +172,8 @@
       <div id="make-request">
         <p>Hmm, we don't have an extract for <span class="name"></span> yet. Would you like to request one?</p>
         <a class="btn btn-transparent" target="_blank">Create <span class="name"></span> Request</a>
-        <p>Otherwise, would one of these work?</p>
       </div>
+      <p class="nearby-text">Otherwise, would one of these work?</p>
       <div id='extracts'></div>
       <div class='row' id='request'>
         <p>Can't find what you're looking for? Request one!</p>
@@ -417,8 +417,10 @@
             bbox : l.feature.bbox
           })
       });
-      console.log(nearby)
-      drawList(nearby);
+      if (nearby[0].values.length){
+        d3.select(".nearby-text").style("display","block");
+        drawList(nearby);
+      }
 
       d3.select("#make-request").style("display","block")
         .selectAll(".name").text(metro.properties.name);
@@ -467,6 +469,7 @@
       clearMap();
       d3.select("#request").style("display","block");
       d3.select("#make-request").style("display","none");
+      d3.select(".nearby-text").style("display","none");
     }
 
     var keyIndex = -1;

--- a/App/static/index.html
+++ b/App/static/index.html
@@ -59,6 +59,9 @@
       .leaflet-container .leaflet-control-zoom-out {
         color: #000;
       }
+      #extracts {
+        margin-bottom: 50px;
+      }
       .country {
         border-top: 1px solid rgb(224,224,224);
         margin-top: 20px;
@@ -99,11 +102,9 @@
       }
       .nearby-text {
         display: none;
-        margin-top: 50px;
       }
       #request {
         background: rgb(224,224,224);
-        margin: 50px 0;
         padding: 20px;
       }
       .autocomplete {
@@ -170,13 +171,13 @@
         <input id='search_submit' type="submit" value="search" class="col-xs-4 col-sm-3 btn btn-transparent">
         <div class="autocomplete"></div>
       </div>
+      <p class="nearby-text">We do have some extracts that are near to your request: </p>
+      <div id='extracts'></div>
       <div id="make-request">
         <p>Hmm, we don't have an extract for <span class="name"></span> yet. Would you like to request one?</p>
         <a class="btn btn-transparent" target="_blank">Create <span class="name"></span> Request</a>
       </div>
-      <p class="nearby-text">We do have some extracts that are nearby to your request: </p>
-      <div id='extracts'></div>
-      <div class='row' id='request'>
+      <div id='request'>
         <p>Can't find what you're looking for? Request one!</p>
         <div class='btn btn-transparent'>Submit GH Issue</div>
       </div>
@@ -242,7 +243,7 @@
 
       return displayMap
     }
-    
+
     var mapurl = 'https://s3.amazonaws.com/metro-extracts.mapzen.com/cities.geojson';
 
     var onEachFeature = function (feature, layer) {

--- a/App/static/index.html
+++ b/App/static/index.html
@@ -99,6 +99,7 @@
       }
       .nearby-text {
         display: none;
+        margin-top: 50px;
       }
       #request {
         background: rgb(224,224,224);
@@ -173,7 +174,7 @@
         <p>Hmm, we don't have an extract for <span class="name"></span> yet. Would you like to request one?</p>
         <a class="btn btn-transparent" target="_blank">Create <span class="name"></span> Request</a>
       </div>
-      <p class="nearby-text">Otherwise, would one of these work?</p>
+      <p class="nearby-text">We do have some extracts that are nearby to your request: </p>
       <div id='extracts'></div>
       <div class='row' id='request'>
         <p>Can't find what you're looking for? Request one!</p>


### PR DESCRIPTION
closes #37 

https://mapzen-odes-extracts-pr-42.herokuapp.com/static/index.html

![screen shot 2016-06-22 at 3 12 55 pm](https://cloud.githubusercontent.com/assets/589151/16285579/da380e24-388b-11e6-91e4-29616361b747.png)
If the requested extract at least partially contained by a neighboring extract, show that in the cities list below

![screen shot 2016-06-22 at 3 08 55 pm](https://cloud.githubusercontent.com/assets/589151/16285529/7bd378dc-388b-11e6-8f07-ffc7baecf173.png)
If not, just show the request button
