### PR TITLE
Switch to using local cities json

### DIFF
--- a/App/__init__.py
+++ b/App/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, Response, render_template
+from flask import Blueprint, jsonify, Response, render_template, url_for
 from itertools import groupby
 from operator import itemgetter
 from os.path import join, dirname
@@ -50,6 +50,7 @@ def get_cities_geojson():
         feature['geometry'] = dict(type='Polygon')
         feature['geometry']['coordinates'] = [[[x1, y1], [x1, y2], [x2, y2], [x2, y1], [x1, y1]]]
         feature['properties'] = dict(name=city['id'], display_name=city['name'])
+        feature['properties']['href'] = url_for('Metro-Extracts.get_metro', metro_id=city['id'])
         features.append(feature)
 
     return jsonify(dict(features=features))

--- a/App/__init__.py
+++ b/App/__init__.py
@@ -1,12 +1,23 @@
 from flask import Blueprint, jsonify, Response, render_template
 from itertools import groupby
 from operator import itemgetter
+from os.path import join, dirname
 import json
 
 import requests
 import uritemplate
 
 blueprint = Blueprint('Metro-Extracts', __name__)
+
+def load_cities(filename):
+    '''
+    '''
+    with open(filename) as file:
+        cities = json.load(file)
+    
+    return cities
+
+cities = load_cities(join(dirname(__file__), '..', 'cities.json'))
 
 def apply_blueprint(app):
     '''
@@ -15,9 +26,6 @@ def apply_blueprint(app):
 
 @blueprint.route('/')
 def index():
-    with open('cities.json') as file:
-        cities = json.load(file)
-    
     ordered_cities = sorted(cities, key=itemgetter('country'))
     metros_tree = list()
     
@@ -28,6 +36,23 @@ def index():
             })
     
     return render_template('index.html', metros_tree=metros_tree)
+
+@blueprint.route('/cities.geojson')
+def get_cities_geojson():
+    features = list()
+    
+    for city in cities:
+        x1, y1, x2, y2 = [float(city['bbox'][k])
+                          for k in ('left', 'bottom', 'right', 'top')]
+
+        feature = dict(type='Feature', id=city['name'])
+        #feature['bbox'] = [x1, y1, x2, y2]
+        feature['geometry'] = dict(type='Polygon')
+        feature['geometry']['coordinates'] = [[[x1, y1], [x1, y2], [x2, y2], [x2, y1], [x1, y1]]]
+        feature['properties'] = dict(name=city['name'])
+        features.append(feature)
+
+    return jsonify(dict(features=features))
 
 @blueprint.route('/metro/<name>')
 def metro(name):

--- a/App/__init__.py
+++ b/App/__init__.py
@@ -45,20 +45,20 @@ def get_cities_geojson():
         x1, y1, x2, y2 = [float(city['bbox'][k])
                           for k in ('left', 'bottom', 'right', 'top')]
 
-        feature = dict(type='Feature', id=city['name'])
+        feature = dict(type='Feature', id=city['id'])
         #feature['bbox'] = [x1, y1, x2, y2]
         feature['geometry'] = dict(type='Polygon')
         feature['geometry']['coordinates'] = [[[x1, y1], [x1, y2], [x2, y2], [x2, y1], [x1, y1]]]
-        feature['properties'] = dict(name=city['name'])
+        feature['properties'] = dict(name=city['id'], display_name=city['name'])
         features.append(feature)
 
     return jsonify(dict(features=features))
 
-@blueprint.route('/metro/<name>')
-def metro(name):
+@blueprint.route('/metro/<metro_id>')
+def get_metro(metro_id):
     with open('cities.json') as file:
         cities = json.load(file)
-        metro = {c['name']: c for c in cities}[name]
+        metro = {c['id']: c for c in cities}[metro_id]
     
     return render_template('metro.html', metro=metro)
 

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -103,7 +103,6 @@
     background: #ccc;
   }
   .city {
-    text-transform: capitalize;
     margin: 3px 0 3px 10px;
     cursor: pointer;
     clear: both;
@@ -261,10 +260,7 @@
 
   var onEachFeature = function (feature, layer) {
     extractLayers.push(layer);
-    if (feature.properties && feature.properties.name) {
-      var text = feature.properties.name;
-      layer.bindPopup("<a href='/metro/"+text+"'>"+text.split("_")[0].replace(/-/g," ").capitalize()+"</a>");
-    }
+    layer.bindPopup("<a href='"+feature.properties.href+"'>"+feature.properties.display_name+"</a>");
   }
 
   // Setup map
@@ -290,9 +286,9 @@
       });
     var cities = countries.selectAll(".city").data(function(d){ return d.metros; });
     cities.enter().append("a").attr("class","city");
-    cities.text(function(d){ return d.name.split("_")[0].replace(/-/g," "); })
+    cities.text(function(d){ return d.name; })
       .attr("href",function(d){ 
-        return "./metro/"+d.name; 
+        return "./metro/"+d.id; 
       });
     cities.exit().remove();
   }
@@ -411,9 +407,9 @@
         metros : []
       }];
       extractLayers.forEach(function(l){
-        if (l.getBounds().contains(p1) && l.getBounds().contains(p2)) 
+        if (l.getBounds().contains(p1) && l.getBounds().contains(p2))
           encompassed[0].metros.push({
-            name : l.feature.properties.name,
+            name : l.feature.properties.display_name,
             country : l.feature.properties.name.split("_")[1],
             bbox : l.feature.bbox
           })
@@ -473,15 +469,10 @@
     d3.select("#did-you-mean").style("display","none");
     d3.select("#request").style("display","block");
     d3.select("#make-request").style("display","none");
+    d3.selectAll(".encompassed-text").style("display","none");
   }
 
   var keyIndex = -1;
-
-  String.prototype.capitalize = function() {
-    var words = this.split(" "),
-      capitalized = words.map(function(w){ return w.charAt(0).toUpperCase() + w.slice(1); });
-    return capitalized.join(" ");
-  }
 
   d3.select("#search_submit").on("click",function(){
     var val = document.getElementById("search_input").value;
@@ -537,8 +528,9 @@
 
   function filterList(str) {
     var newData = [];
+    str = str.toLowerCase();
     nestedCities.forEach(function(d){
-      if (d.country.replace(/-/g," ").indexOf(str) != -1) {
+      if (d.country.toLowerCase().indexOf(str) != -1) {
         newData.push(d);
       } else {
         var c = {
@@ -546,7 +538,7 @@
           metros : []
         }
         d.metros.forEach(function(e){ 
-          if (e.name.split("_")[0].replace(/-/g," ").indexOf(str) != -1)
+          if (e.name.toLowerCase().indexOf(str) != -1)
             c.metros.push(e);
         });
         if (c.metros.length) newData.push(c);

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -193,7 +193,7 @@
           <div class="country">
             <div class="country-name">{{ country_metros.country }}</div>
             {% for metro in country_metros.metros %}
-              <a class="city" href="metro/{{ metro.name }}">{{ metro.name.split("_")[0].replace("-"," ") }}</a>
+              <a class="city" href="{{ url_for('Metro-Extracts.get_metro', metro_id=metro['id']) }}">{{ metro.name }}</a>
             {% endfor %}
           </div>
         {% endfor %}

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -257,7 +257,7 @@
 
     return displayMap
   }
-  var mapurl = 'https://s3.amazonaws.com/metro-extracts.mapzen.com/cities.geojson';
+  var mapurl = '{{ url_for('Metro-Extracts.get_cities_geojson') }}';
 
   var onEachFeature = function (feature, layer) {
     extractLayers.push(layer);

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -196,7 +196,6 @@
         <input id='search_submit' type="submit" value="search" class="col-xs-4 col-sm-3 btn btn-transparent">
         <div class="autocomplete"></div>
       </div>
-<<<<<<< HEAD
       <div id="request-wrapper">
         <p id="did-you-mean">Did you mean <span class="name"></span>?</p>
         <p class="encompassed-text request-messaging">Your extract is included inside of a larger area: </p>
@@ -302,9 +301,7 @@
     var cities = countries.selectAll(".city").data(function(d){ return d.metros; });
     cities.enter().append("a").attr("class","city");
     cities.text(function(d){ return d.name; })
-      .attr("href",function(d){ 
-        return "./metro/"+d.id; 
-      });
+      .attr("href",function(d){ return d.href; });
     cities.exit().remove();
   }
 

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -52,13 +52,13 @@
 {% block content %}
   <div class="container-fluid">
     <div class="col-xs-12">
-      <h1>Metro Extract: {{ metro.name.split("_")[0].replace("-"," ") }}</h1>
+      <h1>Metro Extract: {{ metro.name }}</h1>
     </div>
     <div class="col-sm-6 col-xs-12">
       <div id="map"></div>
     </div>
     <div class="col-sm-6 col-xs-12">
-      <p>To get started with <span class="name">{{ metro.name.split("_")[0].replace("-"," ") }}</span>, download your preferred file format.</p>
+      <p>To get started with <span class="name">{{ metro.name }}</span>, download your preferred file format.</p>
       <p>Need help deciding? Check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
       <div id="downloads">
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.osm.pbf">OSM PBF</a>

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -39,9 +39,6 @@
     padding: 5px 15px;
     margin: 0 10px 10px 0;
   }
-  .name {
-    text-transform: capitalize;
-  }
   @media (max-width: 768px) {
     body.data-pages #map {
       height: 300px;
@@ -61,14 +58,14 @@
       <p>To get started with <span class="name">{{ metro.name }}</span>, download your preferred file format.</p>
       <p>Need help deciding? Check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
       <div id="downloads">
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.osm.pbf">OSM PBF</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.osm.xml">OSM XML</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.osm2pgsql-shapefiles.zip">OSM2PGSQL SHP</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.osm2pgsql-geojson.zip">OSM2PGSQL GEOJSON</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.imposm-shapefiles.zip">IMPOSM SHP</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.imposm-geojson.zip">IMPOSM GEOJSON</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.water.coastline.zip">WATER COASTLINE SHP</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.name }}.land.coastline.zip">LAND COASTLINE SHP</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.pbf">OSM PBF</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.xml">OSM XML</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-shapefiles.zip">OSM2PGSQL SHP</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-geojson.zip">OSM2PGSQL GEOJSON</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-shapefiles.zip">IMPOSM SHP</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-geojson.zip">IMPOSM GEOJSON</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.water.coastline.zip">WATER COASTLINE SHP</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.land.coastline.zip">LAND COASTLINE SHP</a>
       </div>
       <h2>About</h2>
       <p>Mapzen Metro Extracts are produced via a <a href="https://github.com/mapzen/chef-metroextractor">chef cookbook</a> derived from the work of <a href="http://metro.teczno.com">Michal Migurski</a>.</p>
@@ -120,13 +117,7 @@
     var rect = new L.Rectangle(new L.LatLngBounds([southwest, northeast]), { className : "blue" });
     displayMap.addLayer(rect);
 
-    return displayMap
-  }
-
-  String.prototype.capitalize = function() {
-    var words = this.split(" "),
-      capitalized = words.map(function(w){ return w.charAt(0).toUpperCase() + w.slice(1); });
-    return capitalized.join(" ");
+    return displayMap;
   }
 
   var displayMap = initDisplayMap(metro.bbox);

--- a/cities.json
+++ b/cities.json
@@ -1,6 +1,7 @@
 [
     {
-        "name": "abidjan_ivory-coast",
+        "id": "abidjan_ivory-coast",
+        "name": "Abidjan",
         "region": "africa",
         "country": "ivory-coast",
         "bbox": {
@@ -11,7 +12,8 @@
         }
     },
     {
-        "name": "abuja_nigeria",
+        "id": "abuja_nigeria",
+        "name": "Abuja",
         "region": "africa",
         "country": "nigeria",
         "bbox": {
@@ -22,7 +24,8 @@
         }
     },
     {
-        "name": "accra_ghana",
+        "id": "accra_ghana",
+        "name": "Accra",
         "region": "africa",
         "country": "ghana",
         "bbox": {
@@ -33,7 +36,8 @@
         }
     },
     {
-        "name": "addis-abeba_ethiopia",
+        "id": "addis-abeba_ethiopia",
+        "name": "Addis-Abeba",
         "region": "africa",
         "country": "ethiopia",
         "bbox": {
@@ -44,7 +48,8 @@
         }
     },
     {
-        "name": "alexandria_egypt",
+        "id": "alexandria_egypt",
+        "name": "Alexandria",
         "region": "africa",
         "country": "egypt",
         "bbox": {
@@ -55,7 +60,8 @@
         }
     },
     {
-        "name": "algiers_algeria",
+        "id": "algiers_algeria",
+        "name": "Algiers",
         "region": "africa",
         "country": "algeria",
         "bbox": {
@@ -66,7 +72,8 @@
         }
     },
     {
-        "name": "cairo_egypt",
+        "id": "cairo_egypt",
+        "name": "Cairo",
         "region": "africa",
         "country": "egypt",
         "bbox": {
@@ -77,7 +84,8 @@
         }
     },
     {
-        "name": "cape-town_south-africa",
+        "id": "cape-town_south-africa",
+        "name": "Cape Town",
         "region": "africa",
         "country": "south-africa",
         "bbox": {
@@ -88,7 +96,8 @@
         }
     },
     {
-        "name": "casablanca_morocco",
+        "id": "casablanca_morocco",
+        "name": "Casablanca",
         "region": "africa",
         "country": "morocco",
         "bbox": {
@@ -99,7 +108,8 @@
         }
     },
     {
-        "name": "dar-es-salaam_tanzania",
+        "id": "dar-es-salaam_tanzania",
+        "name": "Dar es Salaam",
         "region": "africa",
         "country": "tanzania",
         "bbox": {
@@ -110,7 +120,8 @@
         }
     },
     {
-        "name": "johannesburg_south-africa",
+        "id": "johannesburg_south-africa",
+        "name": "Johannesburg",
         "region": "africa",
         "country": "south-africa",
         "bbox": {
@@ -121,7 +132,8 @@
         }
     },
     {
-        "name": "lagos_nigeria",
+        "id": "lagos_nigeria",
+        "name": "Lagos",
         "region": "africa",
         "country": "nigeria",
         "bbox": {
@@ -132,7 +144,8 @@
         }
     },
     {
-        "name": "luanda_angola",
+        "id": "luanda_angola",
+        "name": "Luanda",
         "region": "africa",
         "country": "angola",
         "bbox": {
@@ -143,7 +156,8 @@
         }
     },
     {
-        "name": "nairobi_kenya",
+        "id": "nairobi_kenya",
+        "name": "Nairobi",
         "region": "africa",
         "country": "kenya",
         "bbox": {
@@ -154,7 +168,8 @@
         }
     },
     {
-        "name": "tunis_tunisia",
+        "id": "tunis_tunisia",
+        "name": "Tunis",
         "region": "africa",
         "country": "tunisia",
         "bbox": {
@@ -166,7 +181,8 @@
     },
     
     {
-        "name": "agra_india",
+        "id": "agra_india",
+        "name": "Agra",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -177,7 +193,8 @@
         }
     },
     {
-        "name": "ahmedabad_india",
+        "id": "ahmedabad_india",
+        "name": "Ahmedabad",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -188,7 +205,8 @@
         }
     },
     {
-        "name": "almaty_kazakhstan",
+        "id": "almaty_kazakhstan",
+        "name": "Almaty",
         "region": "asia",
         "country": "kazakhstan",
         "bbox": {
@@ -199,7 +217,8 @@
         }
     },
     {
-        "name": "ankara_turkey",
+        "id": "ankara_turkey",
+        "name": "Ankara",
         "region": "asia",
         "country": "turkey",
         "bbox": {
@@ -210,7 +229,8 @@
         }
     },
     {
-        "name": "astana_kazakhstan",
+        "id": "astana_kazakhstan",
+        "name": "Astana",
         "region": "asia",
         "country": "kazakhstan",
         "bbox": {
@@ -221,7 +241,8 @@
         }
     },
     {
-        "name": "bangkok_thailand",
+        "id": "bangkok_thailand",
+        "name": "Bangkok",
         "region": "asia",
         "country": "thailand",
         "bbox": {
@@ -232,7 +253,8 @@
         }
     },
     {
-        "name": "beijing_china",
+        "id": "beijing_china",
+        "name": "Beijing",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -243,7 +265,8 @@
         }
     },
     {
-        "name": "bengaluru_india",
+        "id": "bengaluru_india",
+        "name": "Bengaluru",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -254,7 +277,8 @@
         }
     },
     {
-        "name": "chengdu_china",
+        "id": "chengdu_china",
+        "name": "Chengdu",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -265,7 +289,8 @@
         }
     },
     {
-        "name": "chennai_india",
+        "id": "chennai_india",
+        "name": "Chennai",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -276,7 +301,8 @@
         }
     },
     {
-        "name": "chongqing_china",
+        "id": "chongqing_china",
+        "name": "Chongqing",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -287,7 +313,8 @@
         }
     },
     {
-        "name": "dhaka_bangladesh",
+        "id": "dhaka_bangladesh",
+        "name": "Dhaka",
         "region": "asia",
         "country": "bangladesh",
         "bbox": {
@@ -298,7 +325,8 @@
         }
     },
     {
-        "name": "guangzhou_china",
+        "id": "guangzhou_china",
+        "name": "Guangzhou",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -309,7 +337,8 @@
         }
     },
     {
-        "name": "hangzhou_china",
+        "id": "hangzhou_china",
+        "name": "Hangzhou",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -320,7 +349,8 @@
         }
     },
     {
-        "name": "hanoi_vietnam",
+        "id": "hanoi_vietnam",
+        "name": "Hanoi",
         "region": "asia",
         "country": "vietnam",
         "bbox": {
@@ -331,7 +361,8 @@
         }
     },
     {
-        "name": "ho-chi-minh-city_vietnam",
+        "id": "ho-chi-minh-city_vietnam",
+        "name": "Ho Chi Minh City",
         "region": "asia",
         "country": "vietnam",
         "bbox": {
@@ -342,7 +373,8 @@
         }
     },
     {
-        "name": "hong-kong_china",
+        "id": "hong-kong_china",
+        "name": "Hong Kong",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -353,7 +385,8 @@
         }
     },
     {
-        "name": "hyderabad_india",
+        "id": "hyderabad_india",
+        "name": "Hyderabad",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -364,7 +397,8 @@
         }
     },
     {
-        "name": "karachi_pakistan",
+        "id": "karachi_pakistan",
+        "name": "Karachi",
         "region": "asia",
         "country": "pakistan",
         "bbox": {
@@ -375,7 +409,8 @@
         }
     },
     {
-        "name": "kolkata_india",
+        "id": "kolkata_india",
+        "name": "Kolkata",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -386,7 +421,8 @@
         }
     },
     {
-        "name": "kuala-lumpur_malaysia",
+        "id": "kuala-lumpur_malaysia",
+        "name": "Kuala Lumpur",
         "region": "asia",
         "country": "malaysia",
         "bbox": {
@@ -397,7 +433,8 @@
         }
     },
     {
-        "name": "manila_philippines",
+        "id": "manila_philippines",
+        "name": "Manila",
         "region": "asia",
         "country": "philippines",
         "bbox": {
@@ -408,7 +445,8 @@
         }
     },
     {
-        "name": "moscow_russia",
+        "id": "moscow_russia",
+        "name": "Moscow",
         "region": "asia",
         "country": "russia",
         "bbox": {
@@ -419,7 +457,8 @@
         }
     },
     {
-        "name": "mumbai_india",
+        "id": "mumbai_india",
+        "name": "Mumbai",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -430,7 +469,8 @@
         }
     },
     {
-        "name": "new-delhi_india",
+        "id": "new-delhi_india",
+        "name": "New Delhi",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -441,7 +481,8 @@
         }
     },
     {
-        "name": "nizhniy-novgorod_russia",
+        "id": "nizhniy-novgorod_russia",
+        "name": "Nizhniy Novgorod",
         "region": "asia",
         "country": "russia",
         "bbox": {
@@ -452,7 +493,8 @@
         }
     },
     {
-        "name": "perm_russia",
+        "id": "perm_russia",
+        "name": "Perm",
         "region": "asia",
         "country": "russia",
         "bbox": {
@@ -463,7 +505,8 @@
         }
     },
     {
-        "name": "pune_india",
+        "id": "pune_india",
+        "name": "Pune",
         "region": "asia",
         "country": "india",
         "bbox": {
@@ -474,7 +517,8 @@
         }
     },
     {
-        "name": "rangoon_myanmar",
+        "id": "rangoon_myanmar",
+        "name": "Rangoon",
         "region": "asia",
         "country": "myanmar",
         "bbox": {
@@ -485,7 +529,8 @@
         }
     },
     {
-        "name": "saint-petersburg_russia",
+        "id": "saint-petersburg_russia",
+        "name": "Saint Petersburg",
         "region": "asia",
         "country": "russia",
         "bbox": {
@@ -496,7 +541,8 @@
         }
     },
     {
-        "name": "samara-tolyatti_russia",
+        "id": "samara-tolyatti_russia",
+        "name": "Samara Tolyatti",
         "region": "asia",
         "country": "russia",
         "bbox": {
@@ -507,7 +553,8 @@
         }
     },
     {
-        "name": "seoul_south-korea",
+        "id": "seoul_south-korea",
+        "name": "Seoul",
         "region": "asia",
         "country": "south-korea",
         "bbox": {
@@ -518,7 +565,8 @@
         }
     },
     {
-        "name": "shanghai_china",
+        "id": "shanghai_china",
+        "name": "Shanghai",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -529,7 +577,8 @@
         }
     },
     {
-        "name": "shenzhen_china",
+        "id": "shenzhen_china",
+        "name": "Shenzhen",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -540,6 +589,7 @@
         }
     },
     {
+        "id": "singapore",
         "name": "singapore",
         "region": "asia",
         "country": "singapore",
@@ -551,7 +601,8 @@
         }
     },
     {
-        "name": "taipei_taiwan",
+        "id": "taipei_taiwan",
+        "name": "Taipei",
         "region": "asia",
         "country": "taiwan",
         "bbox": {
@@ -562,7 +613,8 @@
         }
     },
     {
-        "name": "tianjin_china",
+        "id": "tianjin_china",
+        "name": "Tianjin",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -573,7 +625,8 @@
         }
     },
     {
-        "name": "tokyo_japan",
+        "id": "tokyo_japan",
+        "name": "Tokyo",
         "region": "asia",
         "country": "japan",
         "bbox": {
@@ -584,7 +637,8 @@
         }
     },
     {
-        "name": "ulaanbaatar_mongolia",
+        "id": "ulaanbaatar_mongolia",
+        "name": "Ulaanbaatar",
         "region": "asia",
         "country": "mongolia",
         "bbox": {
@@ -595,7 +649,8 @@
         }
     },
     {
-        "name": "wuhan_china",
+        "id": "wuhan_china",
+        "name": "Wuhan",
         "region": "asia",
         "country": "china",
         "bbox": {
@@ -607,7 +662,8 @@
     },
 
     {
-        "name": "bratislava_slovakia",
+        "id": "bratislava_slovakia",
+        "name": "Bratislava",
         "region": "eastern_europe",
         "country": "slovakia",
         "bbox": {
@@ -618,7 +674,8 @@
         }
     },
     {
-        "name": "bucharest_romania",
+        "id": "bucharest_romania",
+        "name": "Bucharest",
         "region": "eastern_europe",
         "country": "romania",
         "bbox": {
@@ -629,7 +686,8 @@
         }
     },
     {
-        "name": "budapest_hungary",
+        "id": "budapest_hungary",
+        "name": "Budapest",
         "region": "eastern_europe",
         "country": "hungary",
         "bbox": {
@@ -640,7 +698,8 @@
         }
     },
     {
-        "name": "cluj_romania",
+        "id": "cluj_romania",
+        "name": "Cluj",
         "region": "eastern_europe",
         "country": "romania",
         "bbox": {
@@ -651,7 +710,8 @@
         }
     },
     {
-        "name": "gdansk_poland",
+        "id": "gdansk_poland",
+        "name": "Gdansk",
         "region": "eastern_europe",
         "country": "poland",
         "bbox": {
@@ -662,7 +722,8 @@
         }
     },
     {
-        "name": "istanbul_turkey",
+        "id": "istanbul_turkey",
+        "name": "Istanbul",
         "region": "eastern_europe",
         "country": "turkey",
         "bbox": {
@@ -673,7 +734,8 @@
         }
     },
     {
-        "name": "kharkiv_ukraine",
+        "id": "kharkiv_ukraine",
+        "name": "Kharkiv",
         "region": "eastern_europe",
         "country": "ukraine",
         "bbox": {
@@ -684,7 +746,8 @@
         }
     },
     {
-        "name": "krakow_poland",
+        "id": "krakow_poland",
+        "name": "Krakow",
         "region": "eastern_europe",
         "country": "poland",
         "bbox": {
@@ -695,7 +758,8 @@
         }
     },
     {
-        "name": "kyiv_ukraine",
+        "id": "kyiv_ukraine",
+        "name": "Kyiv",
         "region": "eastern_europe",
         "country": "ukraine",
         "bbox": {
@@ -706,7 +770,8 @@
         }
     },
     {
-        "name": "lviv_ukraine",
+        "id": "lviv_ukraine",
+        "name": "Lviv",
         "region": "eastern_europe",
         "country": "ukraine",
         "bbox": {
@@ -717,7 +782,8 @@
         }
     },
     {
-        "name": "minsk_belarus",
+        "id": "minsk_belarus",
+        "name": "Minsk",
         "region": "eastern_europe",
         "country": "belarus",
         "bbox": {
@@ -728,7 +794,8 @@
         }
     },
     {
-        "name": "poznan_poland",
+        "id": "poznan_poland",
+        "name": "Poznan",
         "region": "eastern_europe",
         "country": "poland",
         "bbox": {
@@ -739,7 +806,8 @@
         }
     },
     {
-        "name": "prague_czech-republic",
+        "id": "prague_czech-republic",
+        "name": "Prague",
         "region": "eastern_europe",
         "country": "czech-republic",
         "bbox": {
@@ -750,7 +818,8 @@
         }
     },
     {
-        "name": "riga_latvia",
+        "id": "riga_latvia",
+        "name": "Riga",
         "region": "eastern_europe",
         "country": "latvia",
         "bbox": {
@@ -761,7 +830,8 @@
         }
     },
     {
-        "name": "sofia_bulgaria",
+        "id": "sofia_bulgaria",
+        "name": "Sofia",
         "region": "eastern_europe",
         "country": "bulgaria",
         "bbox": {
@@ -772,7 +842,8 @@
         }
     },
     {
-        "name": "vienna_austria",
+        "id": "vienna_austria",
+        "name": "Vienna",
         "region": "eastern_europe",
         "country": "austria",
         "bbox": {
@@ -783,7 +854,8 @@
         }
     },
     {
-        "name": "warsaw_poland",
+        "id": "warsaw_poland",
+        "name": "Warsaw",
         "region": "eastern_europe",
         "country": "poland",
         "bbox": {
@@ -794,7 +866,8 @@
         }
     },
     {
-        "name": "wroclaw_poland",
+        "id": "wroclaw_poland",
+        "name": "Wroclaw",
         "region": "eastern_europe",
         "country": "poland",
         "bbox": {
@@ -805,7 +878,8 @@
         }
     },
     {
-        "name": "zagreb_croatia",
+        "id": "zagreb_croatia",
+        "name": "Zagreb",
         "region": "eastern_europe",
         "country": "croatia",
         "bbox": {
@@ -817,7 +891,8 @@
     },
 
     {
-        "name": "adana_turkey",
+        "id": "adana_turkey",
+        "name": "Adana",
         "region": "middle_east",
         "country": "turkey",
         "bbox": {
@@ -828,7 +903,8 @@
         }
     },
     {
-        "name": "amman_jordan",
+        "id": "amman_jordan",
+        "name": "Amman",
         "region": "middle_east",
         "country": "jordan",
         "bbox": {
@@ -839,7 +915,8 @@
         }
     },
     {
-        "name": "baghdad_iraq",
+        "id": "baghdad_iraq",
+        "name": "Baghdad",
         "region": "middle_east",
         "country": "iraq",
         "bbox": {
@@ -850,7 +927,8 @@
         }
     },
     {
-        "name": "doha_qatar",
+        "id": "doha_qatar",
+        "name": "Doha",
         "region": "middle_east",
         "country": "qatar",
         "bbox": {
@@ -861,7 +939,8 @@
         }
     },
     {
-        "name": "dubai_abu-dhabi",
+        "id": "dubai_abu-dhabi",
+        "name": "Dubai",
         "region": "middle_east",
         "country": "abu-dhabi",
         "bbox": {
@@ -872,7 +951,8 @@
         }
     },
     {
-        "name": "izmir_turkey",
+        "id": "izmir_turkey",
+        "name": "Izmir",
         "region": "middle_east",
         "country": "turkey",
         "bbox": {
@@ -883,7 +963,8 @@
         }
     },
     {
-        "name": "jeddah_saudi-arabia",
+        "id": "jeddah_saudi-arabia",
+        "name": "Jeddah",
         "region": "middle_east",
         "country": "saudi-arabia",
         "bbox": {
@@ -894,7 +975,8 @@
         }
     },
     {
-        "name": "jerusalem_israel",
+        "id": "jerusalem_israel",
+        "name": "Jerusalem",
         "region": "middle_east",
         "country": "israel",
         "bbox": {
@@ -905,7 +987,8 @@
         }
     },
     {
-        "name": "riyadh_saudi-arabia",
+        "id": "riyadh_saudi-arabia",
+        "name": "Riyadh",
         "region": "middle_east",
         "country": "saudi-arabia",
         "bbox": {
@@ -916,7 +999,8 @@
         }
     },
     {
-        "name": "tehran_iran",
+        "id": "tehran_iran",
+        "name": "Tehran",
         "region": "middle_east",
         "country": "iran",
         "bbox": {
@@ -927,7 +1011,8 @@
         }
     },
     {
-        "name": "tel-aviv_israel",
+        "id": "tel-aviv_israel",
+        "name": "Tel Aviv",
         "region": "middle_east",
         "country": "israel",
         "bbox": {
@@ -939,7 +1024,8 @@
     },
 
     {
-        "name": "albany_new-york",
+        "id": "albany_new-york",
+        "name": "Albany",
         "region": "north_america",
         "country": "new-york",
         "bbox": {
@@ -950,7 +1036,8 @@
         }
     },
     {
-        "name": "atlanta_georgia",
+        "id": "atlanta_georgia",
+        "name": "Atlanta",
         "region": "north_america",
         "country": "georgia",
         "bbox": {
@@ -961,7 +1048,8 @@
         }
     },
     {
-        "name": "austin_texas",
+        "id": "austin_texas",
+        "name": "Austin",
         "region": "north_america",
         "country": "texas",
         "bbox": {
@@ -972,7 +1060,8 @@
         }
     },
     {
-        "name": "boston_massachusetts",
+        "id": "boston_massachusetts",
+        "name": "Boston",
         "region": "north_america",
         "country": "massachusetts",
         "bbox": {
@@ -983,7 +1072,8 @@
         }
     },
     {
-        "name": "brooklyn_new-york",
+        "id": "brooklyn_new-york",
+        "name": "Brooklyn",
         "region": "north_america",
         "country": "new-york",
         "bbox": {
@@ -994,7 +1084,8 @@
         }
     },
     {
-        "name": "calgary_canada",
+        "id": "calgary_canada",
+        "name": "Calgary",
         "region": "north_america",
         "country": "canada",
         "bbox": {
@@ -1005,7 +1096,8 @@
         }
     },
     {
-        "name": "chicago_illinois",
+        "id": "chicago_illinois",
+        "name": "Chicago",
         "region": "north_america",
         "country": "illinois",
         "bbox": {
@@ -1016,7 +1108,8 @@
         }
     },
     {
-        "name": "cleveland_ohio",
+        "id": "cleveland_ohio",
+        "name": "Cleveland",
         "region": "north_america",
         "country": "ohio",
         "bbox": {
@@ -1027,7 +1120,8 @@
         }
     },
     {
-        "name": "dallas_texas",
+        "id": "dallas_texas",
+        "name": "Dallas",
         "region": "north_america",
         "country": "texas",
         "bbox": {
@@ -1038,7 +1132,8 @@
         }
     },
     {
-        "name": "dc-baltimore_maryland",
+        "id": "dc-baltimore_maryland",
+        "name": "DC/Baltimore",
         "region": "north_america",
         "country": "maryland",
         "bbox": {
@@ -1049,7 +1144,8 @@
         }
     },
     {
-        "name": "denver-boulder_colorado",
+        "id": "denver-boulder_colorado",
+        "name": "Denver/Boulder",
         "region": "north_america",
         "country": "colorado",
         "bbox": {
@@ -1060,7 +1156,8 @@
         }
     },
     {
-        "name": "detroit_michigan",
+        "id": "detroit_michigan",
+        "name": "Detroit",
         "region": "north_america",
         "country": "michigan",
         "bbox": {
@@ -1071,7 +1168,8 @@
         }
     },
     {
-        "name": "edmonton_canada",
+        "id": "edmonton_canada",
+        "name": "Edmonton",
         "region": "north_america",
         "country": "canada",
         "bbox": {
@@ -1082,7 +1180,8 @@
         }
     },
     {
-        "name": "hampton-roads_virginia",
+        "id": "hampton-roads_virginia",
+        "name": "Hampton Roads",
         "region": "north_america",
         "country": "virginia",
         "bbox": {
@@ -1093,7 +1192,8 @@
         }
     },
     {
-        "name": "honolulu_hawaii",
+        "id": "honolulu_hawaii",
+        "name": "Honolulu",
         "region": "north_america",
         "country": "hawaii",
         "bbox": {
@@ -1104,7 +1204,8 @@
         }
     },
     {
-        "name": "houston_texas",
+        "id": "houston_texas",
+        "name": "Houston",
         "region": "north_america",
         "country": "texas",
         "bbox": {
@@ -1115,7 +1216,8 @@
         }
     },
     {
-        "name": "kansas-city-lawrence-topeka_kansas",
+        "id": "kansas-city-lawrence-topeka_kansas",
+        "name": "Kansas City/Lawrence/Topeka",
         "region": "north_america",
         "country": "kansas",
         "bbox": {
@@ -1126,7 +1228,8 @@
         }
     },
     {
-        "name": "la-habana_cuba",
+        "id": "la-habana_cuba",
+        "name": "La Habana",
         "region": "north_america",
         "country": "cuba",
         "bbox": {
@@ -1137,7 +1240,8 @@
         }
     },
     {
-        "name": "las-vegas_nevada",
+        "id": "las-vegas_nevada",
+        "name": "Las Vegas",
         "region": "north_america",
         "country": "nevada",
         "bbox": {
@@ -1148,7 +1252,8 @@
         }
     },
     {
-        "name": "los-angeles_california",
+        "id": "los-angeles_california",
+        "name": "Los Angeles",
         "region": "north_america",
         "country": "california",
         "bbox": {
@@ -1159,7 +1264,8 @@
         }
     },
     {
-        "name": "mexico-city_mexico",
+        "id": "mexico-city_mexico",
+        "name": "Mexico City",
         "region": "north_america",
         "country": "mexico",
         "bbox": {
@@ -1170,7 +1276,8 @@
         }
     },
     {
-        "name": "miami_florida",
+        "id": "miami_florida",
+        "name": "Miami",
         "region": "north_america",
         "country": "florida",
         "bbox": {
@@ -1181,7 +1288,8 @@
         }
     },
     {
-        "name": "minneapolis-saint-paul_minnesota",
+        "id": "minneapolis-saint-paul_minnesota",
+        "name": "Minneapolis/Saint Paul",
         "region": "north_america",
         "country": "minnesota",
         "bbox": {
@@ -1192,7 +1300,8 @@
         }
     },
     {
-        "name": "montreal_canada",
+        "id": "montreal_canada",
+        "name": "Montreal",
         "region": "north_america",
         "country": "canada",
         "bbox": {
@@ -1203,7 +1312,8 @@
         }
     },
     {
-        "name": "nashville_tennessee",
+        "id": "nashville_tennessee",
+        "name": "Nashville",
         "region": "north_america",
         "country": "tennessee",
         "bbox": {
@@ -1214,7 +1324,8 @@
         }
     },
     {
-        "name": "new-orleans_louisiana",
+        "id": "new-orleans_louisiana",
+        "name": "New Orleans",
         "region": "north_america",
         "country": "louisiana",
         "bbox": {
@@ -1225,7 +1336,8 @@
         }
     },
     {
-        "name": "new-york_new-york",
+        "id": "new-york_new-york",
+        "name": "New York",
         "region": "north_america",
         "country": "new-york",
         "bbox": {
@@ -1236,7 +1348,8 @@
         }
     },
     {
-        "name": "ottawa_canada",
+        "id": "ottawa_canada",
+        "name": "Ottawa",
         "region": "north_america",
         "country": "canada",
         "bbox": {
@@ -1247,7 +1360,8 @@
         }
     },
     {
-        "name": "philadelphia_pennsylvania",
+        "id": "philadelphia_pennsylvania",
+        "name": "Philadelphia",
         "region": "north_america",
         "country": "pennsylvania",
         "bbox": {
@@ -1258,7 +1372,8 @@
         }
     },
     {
-        "name": "phoenix_arizona",
+        "id": "phoenix_arizona",
+        "name": "Phoenix",
         "region": "north_america",
         "country": "arizona",
         "bbox": {
@@ -1269,7 +1384,8 @@
         }
     },
     {
-        "name": "pittsburgh_pennsylvania",
+        "id": "pittsburgh_pennsylvania",
+        "name": "Pittsburgh",
         "region": "north_america",
         "country": "pennsylvania",
         "bbox": {
@@ -1280,7 +1396,8 @@
         }
     },
     {
-        "name": "port-au-prince_haiti",
+        "id": "port-au-prince_haiti",
+        "name": "Port au Prince",
         "region": "north_america",
         "country": "haiti",
         "bbox": {
@@ -1291,7 +1408,8 @@
         }
     },
     {
-        "name": "portland_oregon",
+        "id": "portland_oregon",
+        "name": "Portland",
         "region": "north_america",
         "country": "oregon",
         "bbox": {
@@ -1302,7 +1420,8 @@
         }
     },
     {
-        "name": "raleigh_north-carolina",
+        "id": "raleigh_north-carolina",
+        "name": "Raleigh",
         "region": "north_america",
         "country": "north-carolina",
         "bbox": {
@@ -1313,7 +1432,8 @@
         }
     },
     {
-        "name": "saint-louis_missouri",
+        "id": "saint-louis_missouri",
+        "name": "Saint Louis",
         "region": "north_america",
         "country": "missouri",
         "bbox": {
@@ -1324,7 +1444,8 @@
         }
     },
     {
-        "name": "san-antonio_texas",
+        "id": "san-antonio_texas",
+        "name": "San Antonio",
         "region": "north_america",
         "country": "texas",
         "bbox": {
@@ -1335,7 +1456,8 @@
         }
     },
     {
-        "name": "san-diego-tijuana_mexico",
+        "id": "san-diego-tijuana_mexico",
+        "name": "San Diego/Tijuana",
         "region": "north_america",
         "country": "mexico",
         "bbox": {
@@ -1346,7 +1468,8 @@
         }
     },
     {
-        "name": "san-diego_california",
+        "id": "san-diego_california",
+        "name": "San Diego",
         "region": "north_america",
         "country": "california",
         "bbox": {
@@ -1357,7 +1480,8 @@
         }
     },
     {
-        "name": "san-francisco-bay_california",
+        "id": "san-francisco-bay_california",
+        "name": "San Francisco Bay",
         "region": "north_america",
         "country": "california",
         "bbox": {
@@ -1368,7 +1492,8 @@
         }
     },
     {
-        "name": "san-francisco_california",
+        "id": "san-francisco_california",
+        "name": "San Francisco",
         "region": "north_america",
         "country": "california",
         "bbox": {
@@ -1379,7 +1504,8 @@
         }
     },
     {
-        "name": "san-jose_california",
+        "id": "san-jose_california",
+        "name": "San Jose",
         "region": "north_america",
         "country": "california",
         "bbox": {
@@ -1390,7 +1516,8 @@
         }
     },
     {
-        "name": "seattle_washington",
+        "id": "seattle_washington",
+        "name": "Seattle",
         "region": "north_america",
         "country": "washington",
         "bbox": {
@@ -1401,7 +1528,8 @@
         }
     },
     {
-        "name": "tampa_florida",
+        "id": "tampa_florida",
+        "name": "Tampa",
         "region": "north_america",
         "country": "florida",
         "bbox": {
@@ -1412,7 +1540,8 @@
         }
     },
     {
-        "name": "toronto_canada",
+        "id": "toronto_canada",
+        "name": "Toronto",
         "region": "north_america",
         "country": "canada",
         "bbox": {
@@ -1423,7 +1552,8 @@
         }
     },
     {
-        "name": "vancouver_canada",
+        "id": "vancouver_canada",
+        "name": "Vancouver",
         "region": "north_america",
         "country": "canada",
         "bbox": {
@@ -1434,7 +1564,8 @@
         }
     },
     {
-        "name": "victoria_canada",
+        "id": "victoria_canada",
+        "name": "Victoria",
         "region": "north_america",
         "country": "canada",
         "bbox": {
@@ -1446,7 +1577,8 @@
     },
 
     {
-        "name": "aarhus_denmark",
+        "id": "aarhus_denmark",
+        "name": "Aarhus",
         "region": "northern_europe",
         "country": "denmark",
         "bbox": {
@@ -1457,7 +1589,8 @@
         }
     },
     {
-        "name": "gothenburg_sweden",
+        "id": "gothenburg_sweden",
+        "name": "Gothenburg",
         "region": "northern_europe",
         "country": "sweden",
         "bbox": {
@@ -1468,7 +1601,8 @@
         }
     },
     {
-        "name": "helsinki_finland",
+        "id": "helsinki_finland",
+        "name": "Helsinki",
         "region": "northern_europe",
         "country": "finland",
         "bbox": {
@@ -1479,7 +1613,8 @@
         }
     },
     {
-        "name": "oslo_norway",
+        "id": "oslo_norway",
+        "name": "Oslo",
         "region": "northern_europe",
         "country": "norway",
         "bbox": {
@@ -1490,7 +1625,8 @@
         }
     },
     {
-        "name": "reykjavik_iceland",
+        "id": "reykjavik_iceland",
+        "name": "Reykjavik",
         "region": "northern_europe",
         "country": "iceland",
         "bbox": {
@@ -1501,7 +1637,8 @@
         }
     },
     {
-        "name": "stockholm_sweden",
+        "id": "stockholm_sweden",
+        "name": "Stockholm",
         "region": "northern_europe",
         "country": "sweden",
         "bbox": {
@@ -1513,7 +1650,8 @@
     },
 
     {
-        "name": "adelaide_australia",
+        "id": "adelaide_australia",
+        "name": "Adelaide",
         "region": "oceania",
         "country": "australia",
         "bbox": {
@@ -1524,7 +1662,8 @@
         }
     },
     {
-        "name": "auckland_new-zealand",
+        "id": "auckland_new-zealand",
+        "name": "Auckland",
         "region": "oceania",
         "country": "new-zealand",
         "bbox": {
@@ -1535,7 +1674,8 @@
         }
     },
     {
-        "name": "bali_indonesia",
+        "id": "bali_indonesia",
+        "name": "Bali",
         "region": "oceania",
         "country": "indonesia",
         "bbox": {
@@ -1546,7 +1686,8 @@
         }
     },
     {
-        "name": "bandung_indonesia",
+        "id": "bandung_indonesia",
+        "name": "Bandung",
         "region": "oceania",
         "country": "indonesia",
         "bbox": {
@@ -1557,7 +1698,8 @@
         }
     },
     {
-        "name": "brisbane_australia",
+        "id": "brisbane_australia",
+        "name": "Brisbane",
         "region": "oceania",
         "country": "australia",
         "bbox": {
@@ -1568,7 +1710,8 @@
         }
     },
     {
-        "name": "jakarta_indonesia",
+        "id": "jakarta_indonesia",
+        "name": "Jakarta",
         "region": "oceania",
         "country": "indonesia",
         "bbox": {
@@ -1579,7 +1722,8 @@
         }
     },
     {
-        "name": "melbourne_australia",
+        "id": "melbourne_australia",
+        "name": "Melbourne",
         "region": "oceania",
         "country": "australia",
         "bbox": {
@@ -1590,7 +1734,8 @@
         }
     },
     {
-        "name": "perth_australia",
+        "id": "perth_australia",
+        "name": "Perth",
         "region": "oceania",
         "country": "australia",
         "bbox": {
@@ -1601,7 +1746,8 @@
         }
     },
     {
-        "name": "sydney_australia",
+        "id": "sydney_australia",
+        "name": "Sydney",
         "region": "oceania",
         "country": "australia",
         "bbox": {
@@ -1613,7 +1759,8 @@
     },
 
     {
-        "name": "bogota_colombia",
+        "id": "bogota_colombia",
+        "name": "Bogota",
         "region": "south_america",
         "country": "colombia",
         "bbox": {
@@ -1624,7 +1771,8 @@
         }
     },
     {
-        "name": "brasilia_brazil",
+        "id": "brasilia_brazil",
+        "name": "Brasilia",
         "region": "south_america",
         "country": "brazil",
         "bbox": {
@@ -1635,7 +1783,8 @@
         }
     },
     {
-        "name": "buenos-aires_argentina",
+        "id": "buenos-aires_argentina",
+        "name": "Buenos Aires",
         "region": "south_america",
         "country": "argentina",
         "bbox": {
@@ -1646,7 +1795,8 @@
         }
     },
     {
-        "name": "caracas_venezuela",
+        "id": "caracas_venezuela",
+        "name": "Caracas",
         "region": "south_america",
         "country": "venezuela",
         "bbox": {
@@ -1657,7 +1807,8 @@
         }
     },
     {
-        "name": "lima_peru",
+        "id": "lima_peru",
+        "name": "Lima",
         "region": "south_america",
         "country": "peru",
         "bbox": {
@@ -1668,7 +1819,8 @@
         }
     },
     {
-        "name": "medellin_colombia",
+        "id": "medellin_colombia",
+        "name": "Medellin",
         "region": "south_america",
         "country": "colombia",
         "bbox": {
@@ -1679,7 +1831,8 @@
         }
     },
     {
-        "name": "rio-de-janeiro_brazil",
+        "id": "rio-de-janeiro_brazil",
+        "name": "Rio de Janeiro",
         "region": "south_america",
         "country": "brazil",
         "bbox": {
@@ -1690,7 +1843,8 @@
         }
     },
     {
-        "name": "santiago_chile",
+        "id": "santiago_chile",
+        "name": "Santiago",
         "region": "south_america",
         "country": "chile",
         "bbox": {
@@ -1701,7 +1855,8 @@
         }
     },
     {
-        "name": "sao-paulo_brazil",
+        "id": "sao-paulo_brazil",
+        "name": "Sao Paulo",
         "region": "south_america",
         "country": "brazil",
         "bbox": {
@@ -1713,7 +1868,8 @@
     },
 
     {
-        "name": "acoruna_spain",
+        "id": "acoruna_spain",
+        "name": "Acoruna",
         "region": "southern_europe",
         "country": "spain",
         "bbox": {
@@ -1724,7 +1880,8 @@
         }
     },
     {
-        "name": "athens_greece",
+        "id": "athens_greece",
+        "name": "Athens",
         "region": "southern_europe",
         "country": "greece",
         "bbox": {
@@ -1735,7 +1892,8 @@
         }
     },
     {
-        "name": "barcelona_spain",
+        "id": "barcelona_spain",
+        "name": "Barcelona",
         "region": "southern_europe",
         "country": "spain",
         "bbox": {
@@ -1746,7 +1904,8 @@
         }
     },
     {
-        "name": "bologna_italy",
+        "id": "bologna_italy",
+        "name": "Bologna",
         "region": "southern_europe",
         "country": "italy",
         "bbox": {
@@ -1757,7 +1916,8 @@
         }
     },
     {
-        "name": "florence_italy",
+        "id": "florence_italy",
+        "name": "Florence",
         "region": "southern_europe",
         "country": "italy",
         "bbox": {
@@ -1768,7 +1928,8 @@
         }
     },
     {
-        "name": "genoa_italy",
+        "id": "genoa_italy",
+        "name": "Genoa",
         "region": "southern_europe",
         "country": "italy",
         "bbox": {
@@ -1779,7 +1940,8 @@
         }
     },
     {
-        "name": "lisbon_portugal",
+        "id": "lisbon_portugal",
+        "name": "Lisbon",
         "region": "southern_europe",
         "country": "portugal",
         "bbox": {
@@ -1790,7 +1952,8 @@
         }
     },
     {
-        "name": "madrid_spain",
+        "id": "madrid_spain",
+        "name": "Madrid",
         "region": "southern_europe",
         "country": "spain",
         "bbox": {
@@ -1801,7 +1964,8 @@
         }
     },
     {
-        "name": "milan_italy",
+        "id": "milan_italy",
+        "name": "Milan",
         "region": "southern_europe",
         "country": "italy",
         "bbox": {
@@ -1812,7 +1976,8 @@
         }
     },
     {
-        "name": "naples_italy",
+        "id": "naples_italy",
+        "name": "Naples",
         "region": "southern_europe",
         "country": "italy",
         "bbox": {
@@ -1823,7 +1988,8 @@
         }
     },
     {
-        "name": "porto_portugal",
+        "id": "porto_portugal",
+        "name": "Porto",
         "region": "southern_europe",
         "country": "portugal",
         "bbox": {
@@ -1834,7 +2000,8 @@
         }
     },
     {
-        "name": "rome_italy",
+        "id": "rome_italy",
+        "name": "Rome",
         "region": "southern_europe",
         "country": "italy",
         "bbox": {
@@ -1845,7 +2012,8 @@
         }
     },
     {
-        "name": "thessaloniki_greece",
+        "id": "thessaloniki_greece",
+        "name": "Thessaloniki",
         "region": "southern_europe",
         "country": "greece",
         "bbox": {
@@ -1856,7 +2024,8 @@
         }
     },
     {
-        "name": "valencia_spain",
+        "id": "valencia_spain",
+        "name": "Valencia",
         "region": "southern_europe",
         "country": "spain",
         "bbox": {
@@ -1867,7 +2036,8 @@
         }
     },
     {
-        "name": "venice_italy",
+        "id": "venice_italy",
+        "name": "Venice",
         "region": "southern_europe",
         "country": "italy",
         "bbox": {
@@ -1879,7 +2049,8 @@
     },
 
     {
-        "name": "amsterdam_netherlands",
+        "id": "amsterdam_netherlands",
+        "name": "Amsterdam",
         "region": "western_europe",
         "country": "netherlands",
         "bbox": {
@@ -1890,7 +2061,8 @@
         }
     },
     {
-        "name": "antwerp_belgium",
+        "id": "antwerp_belgium",
+        "name": "Antwerp",
         "region": "western_europe",
         "country": "belgium",
         "bbox": {
@@ -1901,7 +2073,8 @@
         }
     },
     {
-        "name": "belfast_ireland",
+        "id": "belfast_ireland",
+        "name": "Belfast",
         "region": "western_europe",
         "country": "ireland",
         "bbox": {
@@ -1912,7 +2085,8 @@
         }
     },
     {
-        "name": "berlin_germany",
+        "id": "berlin_germany",
+        "name": "Berlin",
         "region": "western_europe",
         "country": "germany",
         "bbox": {
@@ -1923,7 +2097,8 @@
         }
     },
     {
-        "name": "bern_switzerland",
+        "id": "bern_switzerland",
+        "name": "Bern",
         "region": "western_europe",
         "country": "switzerland",
         "bbox": {
@@ -1934,7 +2109,8 @@
         }
     },
     {
-        "name": "birmingham_england",
+        "id": "birmingham_england",
+        "name": "Birmingham",
         "region": "western_europe",
         "country": "england",
         "bbox": {
@@ -1945,7 +2121,8 @@
         }
     },
     {
-        "name": "bordeaux_france",
+        "id": "bordeaux_france",
+        "name": "Bordeaux",
         "region": "western_europe",
         "country": "france",
         "bbox": {
@@ -1956,7 +2133,8 @@
         }
     },
     {
-        "name": "brussels_belgium",
+        "id": "brussels_belgium",
+        "name": "Brussels",
         "region": "western_europe",
         "country": "belgium",
         "bbox": {
@@ -1967,7 +2145,8 @@
         }
     },
     {
-        "name": "cardiff-newport-bristol-bath_england",
+        "id": "cardiff-newport-bristol-bath_england",
+        "name": "Cardiff/Newport/Bristol/Bath",
         "region": "western_europe",
         "country": "england",
         "bbox": {
@@ -1978,7 +2157,8 @@
         }
     },
     {
-        "name": "cologne_germany",
+        "id": "cologne_germany",
+        "name": "Cologne",
         "region": "western_europe",
         "country": "germany",
         "bbox": {
@@ -1989,7 +2169,8 @@
         }
     },
     {
-        "name": "copenhagen_denmark",
+        "id": "copenhagen_denmark",
+        "name": "Copenhagen",
         "region": "western_europe",
         "country": "denmark",
         "bbox": {
@@ -2000,7 +2181,8 @@
         }
     },
     {
-        "name": "dresden_germany",
+        "id": "dresden_germany",
+        "name": "Dresden",
         "region": "western_europe",
         "country": "germany",
         "bbox": {
@@ -2011,7 +2193,8 @@
         }
     },
     {
-        "name": "dublin_ireland",
+        "id": "dublin_ireland",
+        "name": "Dublin",
         "region": "western_europe",
         "country": "ireland",
         "bbox": {
@@ -2022,7 +2205,8 @@
         }
     },
     {
-        "name": "duesseldorf_germany",
+        "id": "duesseldorf_germany",
+        "name": "Duesseldorf",
         "region": "western_europe",
         "country": "germany",
         "bbox": {
@@ -2033,7 +2217,8 @@
         }
     },
     {
-        "name": "edinburgh_scotland",
+        "id": "edinburgh_scotland",
+        "name": "Edinburgh",
         "region": "western_europe",
         "country": "scotland",
         "bbox": {
@@ -2044,7 +2229,8 @@
         }
     },
     {
-        "name": "frankfurt_germany",
+        "id": "frankfurt_germany",
+        "name": "Frankfurt",
         "region": "western_europe",
         "country": "germany",
         "bbox": {
@@ -2055,7 +2241,8 @@
         }
     },
     {
-        "name": "glasgow_scotland",
+        "id": "glasgow_scotland",
+        "name": "Glasgow",
         "region": "western_europe",
         "country": "scotland",
         "bbox": {
@@ -2066,7 +2253,8 @@
         }
     },
     {
-        "name": "hamburg_germany",
+        "id": "hamburg_germany",
+        "name": "Hamburg",
         "region": "western_europe",
         "country": "germany",
         "bbox": {
@@ -2077,7 +2265,8 @@
         }
     },
     {
-        "name": "liverpool_england",
+        "id": "liverpool_england",
+        "name": "Liverpool",
         "region": "western_europe",
         "country": "england",
         "bbox": {
@@ -2088,7 +2277,8 @@
         }
     },
     {
-        "name": "london_england",
+        "id": "london_england",
+        "name": "London",
         "region": "western_europe",
         "country": "england",
         "bbox": {
@@ -2099,7 +2289,8 @@
         }
     },
     {
-        "name": "lyon_france",
+        "id": "lyon_france",
+        "name": "Lyon",
         "region": "western_europe",
         "country": "france",
         "bbox": {
@@ -2110,7 +2301,8 @@
         }
     },
     {
-        "name": "manchester_england",
+        "id": "manchester_england",
+        "name": "Manchester",
         "region": "western_europe",
         "country": "england",
         "bbox": {
@@ -2121,7 +2313,8 @@
         }
     },
     {
-        "name": "marseille_france",
+        "id": "marseille_france",
+        "name": "Marseille",
         "region": "western_europe",
         "country": "france",
         "bbox": {
@@ -2132,7 +2325,8 @@
         }
     },
     {
-        "name": "munich_germany",
+        "id": "munich_germany",
+        "name": "Munich",
         "region": "western_europe",
         "country": "germany",
         "bbox": {
@@ -2143,7 +2337,8 @@
         }
     },
     {
-        "name": "paris_france",
+        "id": "paris_france",
+        "name": "Paris",
         "region": "western_europe",
         "country": "france",
         "bbox": {
@@ -2154,7 +2349,8 @@
         }
     },
     {
-        "name": "rotterdam_netherlands",
+        "id": "rotterdam_netherlands",
+        "name": "Rotterdam",
         "region": "western_europe",
         "country": "netherlands",
         "bbox": {
@@ -2165,7 +2361,8 @@
         }
     },
     {
-        "name": "southampton_england",
+        "id": "southampton_england",
+        "name": "Southampton",
         "region": "western_europe",
         "country": "england",
         "bbox": {
@@ -2176,7 +2373,8 @@
         }
     },
     {
-        "name": "strasbourg_france",
+        "id": "strasbourg_france",
+        "name": "Strasbourg",
         "region": "western_europe",
         "country": "france",
         "bbox": {
@@ -2187,7 +2385,8 @@
         }
     },
     {
-        "name": "turin_italy",
+        "id": "turin_italy",
+        "name": "Turin",
         "region": "western_europe",
         "country": "italy",
         "bbox": {
@@ -2198,7 +2397,8 @@
         }
     },
     {
-        "name": "zurich_switzerland",
+        "id": "zurich_switzerland",
+        "name": "Zurich",
         "region": "western_europe",
         "country": "switzerland",
         "bbox": {

--- a/cities.json
+++ b/cities.json
@@ -3,7 +3,7 @@
         "id": "abidjan_ivory-coast",
         "name": "Abidjan",
         "region": "africa",
-        "country": "ivory-coast",
+        "country": "Ivory Coast",
         "bbox": {
             "top": "5.523",
             "left": "-4.183",
@@ -15,7 +15,7 @@
         "id": "abuja_nigeria",
         "name": "Abuja",
         "region": "africa",
-        "country": "nigeria",
+        "country": "Nigeria",
         "bbox": {
             "top": "9.246",
             "left": "7.248",
@@ -27,7 +27,7 @@
         "id": "accra_ghana",
         "name": "Accra",
         "region": "africa",
-        "country": "ghana",
+        "country": "Ghana",
         "bbox": {
             "top": "5.675",
             "left": "-0.437",
@@ -39,7 +39,7 @@
         "id": "addis-abeba_ethiopia",
         "name": "Addis-Abeba",
         "region": "africa",
-        "country": "ethiopia",
+        "country": "Ethiopia",
         "bbox": {
             "top": "9.077",
             "left": "38.651",
@@ -51,7 +51,7 @@
         "id": "alexandria_egypt",
         "name": "Alexandria",
         "region": "africa",
-        "country": "egypt",
+        "country": "Egypt",
         "bbox": {
             "top": "31.432",
             "left": "29.689",
@@ -63,7 +63,7 @@
         "id": "algiers_algeria",
         "name": "Algiers",
         "region": "africa",
-        "country": "algeria",
+        "country": "Algeria",
         "bbox": {
             "top": "36.762",
             "left": "3.026",
@@ -75,7 +75,7 @@
         "id": "cairo_egypt",
         "name": "Cairo",
         "region": "africa",
-        "country": "egypt",
+        "country": "Egypt",
         "bbox": {
             "top": "30.564",
             "left": "30.897",
@@ -87,7 +87,7 @@
         "id": "cape-town_south-africa",
         "name": "Cape Town",
         "region": "africa",
-        "country": "south-africa",
+        "country": "South Africa",
         "bbox": {
             "top": "-33.471",
             "left": "18.302",
@@ -99,7 +99,7 @@
         "id": "casablanca_morocco",
         "name": "Casablanca",
         "region": "africa",
-        "country": "morocco",
+        "country": "Morocco",
         "bbox": {
             "top": "33.652",
             "left": "-7.737",
@@ -111,7 +111,7 @@
         "id": "dar-es-salaam_tanzania",
         "name": "Dar es Salaam",
         "region": "africa",
-        "country": "tanzania",
+        "country": "Tanzania",
         "bbox": {
             "top": "-6.502",
             "left": "38.894",
@@ -123,7 +123,7 @@
         "id": "johannesburg_south-africa",
         "name": "Johannesburg",
         "region": "africa",
-        "country": "south-africa",
+        "country": "South Africa",
         "bbox": {
             "top": "-25.834",
             "left": "27.537",
@@ -135,7 +135,7 @@
         "id": "lagos_nigeria",
         "name": "Lagos",
         "region": "africa",
-        "country": "nigeria",
+        "country": "Nigeria",
         "bbox": {
             "top": "6.910",
             "left": "2.889",
@@ -147,7 +147,7 @@
         "id": "luanda_angola",
         "name": "Luanda",
         "region": "africa",
-        "country": "angola",
+        "country": "Angola",
         "bbox": {
             "top": "-8.729",
             "left": "13.086",
@@ -159,7 +159,7 @@
         "id": "nairobi_kenya",
         "name": "Nairobi",
         "region": "africa",
-        "country": "kenya",
+        "country": "Kenya",
         "bbox": {
             "top": "-0.965",
             "left": "36.582",
@@ -171,7 +171,7 @@
         "id": "tunis_tunisia",
         "name": "Tunis",
         "region": "africa",
-        "country": "tunisia",
+        "country": "Tunisia",
         "bbox": {
             "top": "37.008",
             "left": "9.978",
@@ -184,7 +184,7 @@
         "id": "agra_india",
         "name": "Agra",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "27.259",
             "left": "77.886",
@@ -196,7 +196,7 @@
         "id": "ahmedabad_india",
         "name": "Ahmedabad",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "23.201",
             "left": "72.364",
@@ -208,7 +208,7 @@
         "id": "almaty_kazakhstan",
         "name": "Almaty",
         "region": "asia",
-        "country": "kazakhstan",
+        "country": "Kazakhstan",
         "bbox": {
             "top": "43.549",
             "left": "76.575",
@@ -220,7 +220,7 @@
         "id": "ankara_turkey",
         "name": "Ankara",
         "region": "asia",
-        "country": "turkey",
+        "country": "Turkey",
         "bbox": {
             "top": "40.372",
             "left": "32.105",
@@ -232,7 +232,7 @@
         "id": "astana_kazakhstan",
         "name": "Astana",
         "region": "asia",
-        "country": "kazakhstan",
+        "country": "Kazakhstan",
         "bbox": {
             "top": "51.290",
             "left": "71.212",
@@ -244,7 +244,7 @@
         "id": "bangkok_thailand",
         "name": "Bangkok",
         "region": "asia",
-        "country": "thailand",
+        "country": "Thailand",
         "bbox": {
             "top": "15.019",
             "left": "99.569",
@@ -256,7 +256,7 @@
         "id": "beijing_china",
         "name": "Beijing",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "40.426",
             "left": "115.686",
@@ -268,7 +268,7 @@
         "id": "bengaluru_india",
         "name": "Bengaluru",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "13.230",
             "left": "77.350",
@@ -280,7 +280,7 @@
         "id": "chengdu_china",
         "name": "Chengdu",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "30.987",
             "left": "103.564",
@@ -292,7 +292,7 @@
         "id": "chennai_india",
         "name": "Chennai",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "13.300",
             "left": "79.900",
@@ -304,7 +304,7 @@
         "id": "chongqing_china",
         "name": "Chongqing",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "32.217",
             "left": "105.283",
@@ -316,7 +316,7 @@
         "id": "dhaka_bangladesh",
         "name": "Dhaka",
         "region": "asia",
-        "country": "bangladesh",
+        "country": "Bangladesh",
         "bbox": {
             "top": "24.006",
             "left": "89.998",
@@ -328,7 +328,7 @@
         "id": "guangzhou_china",
         "name": "Guangzhou",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "23.981",
             "left": "112.181",
@@ -340,7 +340,7 @@
         "id": "hangzhou_china",
         "name": "Hangzhou",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "30.296",
             "left": "120.100",
@@ -352,7 +352,7 @@
         "id": "hanoi_vietnam",
         "name": "Hanoi",
         "region": "asia",
-        "country": "vietnam",
+        "country": "Vietnam",
         "bbox": {
             "top": "21.098",
             "left": "105.742",
@@ -364,7 +364,7 @@
         "id": "ho-chi-minh-city_vietnam",
         "name": "Ho Chi Minh City",
         "region": "asia",
-        "country": "vietnam",
+        "country": "Vietnam",
         "bbox": {
             "top": "11.021",
             "left": "106.458",
@@ -376,7 +376,7 @@
         "id": "hong-kong_china",
         "name": "Hong Kong",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "23.488",
             "left": "112.780",
@@ -388,7 +388,7 @@
         "id": "hyderabad_india",
         "name": "Hyderabad",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "17.630",
             "left": "78.216",
@@ -400,7 +400,7 @@
         "id": "karachi_pakistan",
         "name": "Karachi",
         "region": "asia",
-        "country": "pakistan",
+        "country": "Pakistan",
         "bbox": {
             "top": "25.593",
             "left": "66.401",
@@ -412,7 +412,7 @@
         "id": "kolkata_india",
         "name": "Kolkata",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "23.106",
             "left": "87.751",
@@ -424,7 +424,7 @@
         "id": "kuala-lumpur_malaysia",
         "name": "Kuala Lumpur",
         "region": "asia",
-        "country": "malaysia",
+        "country": "Malaysia",
         "bbox": {
             "top": "3.407",
             "left": "101.425",
@@ -436,7 +436,7 @@
         "id": "manila_philippines",
         "name": "Manila",
         "region": "asia",
-        "country": "philippines",
+        "country": "Philippines",
         "bbox": {
             "top": "14.900",
             "left": "120.885",
@@ -448,7 +448,7 @@
         "id": "moscow_russia",
         "name": "Moscow",
         "region": "asia",
-        "country": "russia",
+        "country": "Russia",
         "bbox": {
             "top": "56.200",
             "left": "36.800",
@@ -460,7 +460,7 @@
         "id": "mumbai_india",
         "name": "Mumbai",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "19.500",
             "left": "72.415",
@@ -472,7 +472,7 @@
         "id": "new-delhi_india",
         "name": "New Delhi",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "28.969",
             "left": "76.692",
@@ -484,7 +484,7 @@
         "id": "nizhniy-novgorod_russia",
         "name": "Nizhniy Novgorod",
         "region": "asia",
-        "country": "russia",
+        "country": "Russia",
         "bbox": {
             "top": "56.400",
             "left": "43.718",
@@ -496,7 +496,7 @@
         "id": "perm_russia",
         "name": "Perm",
         "region": "asia",
-        "country": "russia",
+        "country": "Russia",
         "bbox": {
             "top": "58.182",
             "left": "55.795",
@@ -508,7 +508,7 @@
         "id": "pune_india",
         "name": "Pune",
         "region": "asia",
-        "country": "india",
+        "country": "India",
         "bbox": {
             "top": "18.771",
             "left": "73.603",
@@ -520,7 +520,7 @@
         "id": "rangoon_myanmar",
         "name": "Rangoon",
         "region": "asia",
-        "country": "myanmar",
+        "country": "Myanmar",
         "bbox": {
             "top": "17.729",
             "left": "95.257",
@@ -532,7 +532,7 @@
         "id": "saint-petersburg_russia",
         "name": "Saint Petersburg",
         "region": "asia",
-        "country": "russia",
+        "country": "Russia",
         "bbox": {
             "top": "60.345",
             "left": "29.168",
@@ -544,7 +544,7 @@
         "id": "samara-tolyatti_russia",
         "name": "Samara Tolyatti",
         "region": "asia",
-        "country": "russia",
+        "country": "Russia",
         "bbox": {
             "top": "54.037",
             "left": "48.500",
@@ -556,7 +556,7 @@
         "id": "seoul_south-korea",
         "name": "Seoul",
         "region": "asia",
-        "country": "south-korea",
+        "country": "South Korea",
         "bbox": {
             "top": "37.980",
             "left": "126.064",
@@ -568,7 +568,7 @@
         "id": "shanghai_china",
         "name": "Shanghai",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "32.472",
             "left": "118.887",
@@ -580,7 +580,7 @@
         "id": "shenzhen_china",
         "name": "Shenzhen",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "22.808",
             "left": "113.755",
@@ -592,7 +592,7 @@
         "id": "singapore",
         "name": "singapore",
         "region": "asia",
-        "country": "singapore",
+        "country": "Singapore",
         "bbox": {
             "top": "1.823",
             "left": "103.062",
@@ -604,7 +604,7 @@
         "id": "taipei_taiwan",
         "name": "Taipei",
         "region": "asia",
-        "country": "taiwan",
+        "country": "Taiwan",
         "bbox": {
             "top": "25.209",
             "left": "121.346",
@@ -616,7 +616,7 @@
         "id": "tianjin_china",
         "name": "Tianjin",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "39.779",
             "left": "116.528",
@@ -628,7 +628,7 @@
         "id": "tokyo_japan",
         "name": "Tokyo",
         "region": "asia",
-        "country": "japan",
+        "country": "Japan",
         "bbox": {
             "top": "36.558",
             "left": "138.779",
@@ -640,7 +640,7 @@
         "id": "ulaanbaatar_mongolia",
         "name": "Ulaanbaatar",
         "region": "asia",
-        "country": "mongolia",
+        "country": "Mongolia",
         "bbox": {
             "top": "48.285",
             "left": "106.344",
@@ -652,7 +652,7 @@
         "id": "wuhan_china",
         "name": "Wuhan",
         "region": "asia",
-        "country": "china",
+        "country": "China",
         "bbox": {
             "top": "30.903",
             "left": "113.745",
@@ -665,7 +665,7 @@
         "id": "bratislava_slovakia",
         "name": "Bratislava",
         "region": "eastern_europe",
-        "country": "slovakia",
+        "country": "Slovakia",
         "bbox": {
             "top": "48.295",
             "left": "16.955",
@@ -677,7 +677,7 @@
         "id": "bucharest_romania",
         "name": "Bucharest",
         "region": "eastern_europe",
-        "country": "romania",
+        "country": "Romania",
         "bbox": {
             "top": "44.729",
             "left": "25.542",
@@ -689,7 +689,7 @@
         "id": "budapest_hungary",
         "name": "Budapest",
         "region": "eastern_europe",
-        "country": "hungary",
+        "country": "Hungary",
         "bbox": {
             "top": "47.861",
             "left": "18.347",
@@ -701,7 +701,7 @@
         "id": "cluj_romania",
         "name": "Cluj",
         "region": "eastern_europe",
-        "country": "romania",
+        "country": "Romania",
         "bbox": {
             "top": "46.830",
             "left": "23.454",
@@ -713,7 +713,7 @@
         "id": "gdansk_poland",
         "name": "Gdansk",
         "region": "eastern_europe",
-        "country": "poland",
+        "country": "Poland",
         "bbox": {
             "top": "54.870",
             "left": "18.174",
@@ -725,7 +725,7 @@
         "id": "istanbul_turkey",
         "name": "Istanbul",
         "region": "eastern_europe",
-        "country": "turkey",
+        "country": "Turkey",
         "bbox": {
             "top": "41.421",
             "left": "28.313",
@@ -737,7 +737,7 @@
         "id": "kharkiv_ukraine",
         "name": "Kharkiv",
         "region": "eastern_europe",
-        "country": "ukraine",
+        "country": "Ukraine",
         "bbox": {
             "top": "50.105",
             "left": "36.106",
@@ -749,7 +749,7 @@
         "id": "krakow_poland",
         "name": "Krakow",
         "region": "eastern_europe",
-        "country": "poland",
+        "country": "Poland",
         "bbox": {
             "top": "50.240",
             "left": "19.594",
@@ -761,7 +761,7 @@
         "id": "kyiv_ukraine",
         "name": "Kyiv",
         "region": "eastern_europe",
-        "country": "ukraine",
+        "country": "Ukraine",
         "bbox": {
             "top": "50.740",
             "left": "30.078",
@@ -773,7 +773,7 @@
         "id": "lviv_ukraine",
         "name": "Lviv",
         "region": "eastern_europe",
-        "country": "ukraine",
+        "country": "Ukraine",
         "bbox": {
             "top": "50.148",
             "left": "23.587",
@@ -785,7 +785,7 @@
         "id": "minsk_belarus",
         "name": "Minsk",
         "region": "eastern_europe",
-        "country": "belarus",
+        "country": "Belarus",
         "bbox": {
             "top": "53.972",
             "left": "27.375",
@@ -797,7 +797,7 @@
         "id": "poznan_poland",
         "name": "Poznan",
         "region": "eastern_europe",
-        "country": "poland",
+        "country": "Poland",
         "bbox": {
             "top": "52.509",
             "left": "16.732",
@@ -809,7 +809,7 @@
         "id": "prague_czech-republic",
         "name": "Prague",
         "region": "eastern_europe",
-        "country": "czech-republic",
+        "country": "Czech Republic",
         "bbox": {
             "top": "50.408",
             "left": "13.842",
@@ -821,7 +821,7 @@
         "id": "riga_latvia",
         "name": "Riga",
         "region": "eastern_europe",
-        "country": "latvia",
+        "country": "Latvia",
         "bbox": {
             "top": "57.300",
             "left": "23.469",
@@ -833,7 +833,7 @@
         "id": "sofia_bulgaria",
         "name": "Sofia",
         "region": "eastern_europe",
-        "country": "bulgaria",
+        "country": "Bulgaria",
         "bbox": {
             "top": "43.040",
             "left": "22.870",
@@ -845,7 +845,7 @@
         "id": "vienna_austria",
         "name": "Vienna",
         "region": "eastern_europe",
-        "country": "austria",
+        "country": "Austria",
         "bbox": {
             "top": "48.386",
             "left": "16.137",
@@ -857,7 +857,7 @@
         "id": "warsaw_poland",
         "name": "Warsaw",
         "region": "eastern_europe",
-        "country": "poland",
+        "country": "Poland",
         "bbox": {
             "top": "52.623",
             "left": "20.341",
@@ -869,7 +869,7 @@
         "id": "wroclaw_poland",
         "name": "Wroclaw",
         "region": "eastern_europe",
-        "country": "poland",
+        "country": "Poland",
         "bbox": {
             "top": "51.311",
             "left": "16.652",
@@ -881,7 +881,7 @@
         "id": "zagreb_croatia",
         "name": "Zagreb",
         "region": "eastern_europe",
-        "country": "croatia",
+        "country": "Croatia",
         "bbox": {
             "top": "45.848",
             "left": "15.810",
@@ -894,7 +894,7 @@
         "id": "adana_turkey",
         "name": "Adana",
         "region": "middle_east",
-        "country": "turkey",
+        "country": "Turkey",
         "bbox": {
             "top": "37.070",
             "left": "35.210",
@@ -906,7 +906,7 @@
         "id": "amman_jordan",
         "name": "Amman",
         "region": "middle_east",
-        "country": "jordan",
+        "country": "Jordan",
         "bbox": {
             "top": "32.171",
             "left": "35.715",
@@ -918,7 +918,7 @@
         "id": "baghdad_iraq",
         "name": "Baghdad",
         "region": "middle_east",
-        "country": "iraq",
+        "country": "Iraq",
         "bbox": {
             "top": "33.715",
             "left": "43.786",
@@ -930,7 +930,7 @@
         "id": "doha_qatar",
         "name": "Doha",
         "region": "middle_east",
-        "country": "qatar",
+        "country": "Qatar",
         "bbox": {
             "top": "25.637",
             "left": "51.240",
@@ -942,7 +942,7 @@
         "id": "dubai_abu-dhabi",
         "name": "Dubai",
         "region": "middle_east",
-        "country": "abu-dhabi",
+        "country": "Abu Dhabi",
         "bbox": {
             "top": "26.539",
             "left": "53.580",
@@ -954,7 +954,7 @@
         "id": "izmir_turkey",
         "name": "Izmir",
         "region": "middle_east",
-        "country": "turkey",
+        "country": "Turkey",
         "bbox": {
             "top": "38.545",
             "left": "26.855",
@@ -966,7 +966,7 @@
         "id": "jeddah_saudi-arabia",
         "name": "Jeddah",
         "region": "middle_east",
-        "country": "saudi-arabia",
+        "country": "Saudi Arabia",
         "bbox": {
             "top": "21.905",
             "left": "39.029",
@@ -978,7 +978,7 @@
         "id": "jerusalem_israel",
         "name": "Jerusalem",
         "region": "middle_east",
-        "country": "israel",
+        "country": "Israel",
         "bbox": {
             "top": "31.866",
             "left": "35.072",
@@ -990,7 +990,7 @@
         "id": "riyadh_saudi-arabia",
         "name": "Riyadh",
         "region": "middle_east",
-        "country": "saudi-arabia",
+        "country": "Saudi Arabia",
         "bbox": {
             "top": "25.098",
             "left": "46.227",
@@ -1002,7 +1002,7 @@
         "id": "tehran_iran",
         "name": "Tehran",
         "region": "middle_east",
-        "country": "iran",
+        "country": "Iran",
         "bbox": {
             "top": "35.917",
             "left": "50.870",
@@ -1014,7 +1014,7 @@
         "id": "tel-aviv_israel",
         "name": "Tel Aviv",
         "region": "middle_east",
-        "country": "israel",
+        "country": "Israel",
         "bbox": {
             "top": "32.246",
             "left": "34.642",
@@ -1027,7 +1027,7 @@
         "id": "albany_new-york",
         "name": "Albany",
         "region": "north_america",
-        "country": "new-york",
+        "country": "United States",
         "bbox": {
             "top": "42.722",
             "left": "-73.898",
@@ -1039,7 +1039,7 @@
         "id": "atlanta_georgia",
         "name": "Atlanta",
         "region": "north_america",
-        "country": "georgia",
+        "country": "United States",
         "bbox": {
             "top": "34.618",
             "left": "-85.386",
@@ -1051,7 +1051,7 @@
         "id": "austin_texas",
         "name": "Austin",
         "region": "north_america",
-        "country": "texas",
+        "country": "United States",
         "bbox": {
             "top": "30.670",
             "left": "-98.212",
@@ -1063,7 +1063,7 @@
         "id": "boston_massachusetts",
         "name": "Boston",
         "region": "north_america",
-        "country": "massachusetts",
+        "country": "United States",
         "bbox": {
             "top": "42.420",
             "left": "-71.191",
@@ -1075,7 +1075,7 @@
         "id": "brooklyn_new-york",
         "name": "Brooklyn",
         "region": "north_america",
-        "country": "new-york",
+        "country": "United States",
         "bbox": {
             "top": "40.739",
             "left": "-74.057",
@@ -1087,7 +1087,7 @@
         "id": "calgary_canada",
         "name": "Calgary",
         "region": "north_america",
-        "country": "canada",
+        "country": "Canada",
         "bbox": {
             "top": "51.353",
             "left": "-114.612",
@@ -1099,7 +1099,7 @@
         "id": "chicago_illinois",
         "name": "Chicago",
         "region": "north_america",
-        "country": "illinois",
+        "country": "United States",
         "bbox": {
             "top": "42.297",
             "left": "-88.505",
@@ -1111,7 +1111,7 @@
         "id": "cleveland_ohio",
         "name": "Cleveland",
         "region": "north_america",
-        "country": "ohio",
+        "country": "United States",
         "bbox": {
             "top": "41.918",
             "left": "-82.485",
@@ -1123,7 +1123,7 @@
         "id": "dallas_texas",
         "name": "Dallas",
         "region": "north_america",
-        "country": "texas",
+        "country": "United States",
         "bbox": {
             "top": "33.431",
             "left": "-97.789",
@@ -1135,7 +1135,7 @@
         "id": "dc-baltimore_maryland",
         "name": "DC/Baltimore",
         "region": "north_america",
-        "country": "maryland",
+        "country": "United States",
         "bbox": {
             "top": "39.631",
             "left": "-77.599",
@@ -1147,7 +1147,7 @@
         "id": "denver-boulder_colorado",
         "name": "Denver/Boulder",
         "region": "north_america",
-        "country": "colorado",
+        "country": "United States",
         "bbox": {
             "top": "40.313",
             "left": "-105.746",
@@ -1159,7 +1159,7 @@
         "id": "detroit_michigan",
         "name": "Detroit",
         "region": "north_america",
-        "country": "michigan",
+        "country": "United States",
         "bbox": {
             "top": "43.168",
             "left": "-84.158",
@@ -1171,7 +1171,7 @@
         "id": "edmonton_canada",
         "name": "Edmonton",
         "region": "north_america",
-        "country": "canada",
+        "country": "Canada",
         "bbox": {
             "top": "54.213",
             "left": "-114.529",
@@ -1183,7 +1183,7 @@
         "id": "hampton-roads_virginia",
         "name": "Hampton Roads",
         "region": "north_america",
-        "country": "virginia",
+        "country": "United States",
         "bbox": {
             "top": "37.208",
             "left": "-76.663",
@@ -1195,7 +1195,7 @@
         "id": "honolulu_hawaii",
         "name": "Honolulu",
         "region": "north_america",
-        "country": "hawaii",
+        "country": "United States",
         "bbox": {
             "top": "21.781",
             "left": "-158.350",
@@ -1207,7 +1207,7 @@
         "id": "houston_texas",
         "name": "Houston",
         "region": "north_america",
-        "country": "texas",
+        "country": "United States",
         "bbox": {
             "top": "30.261",
             "left": "-96.064",
@@ -1219,7 +1219,7 @@
         "id": "kansas-city-lawrence-topeka_kansas",
         "name": "Kansas City/Lawrence/Topeka",
         "region": "north_america",
-        "country": "kansas",
+        "country": "United States",
         "bbox": {
             "top": "39.419",
             "left": "-95.946",
@@ -1231,7 +1231,7 @@
         "id": "la-habana_cuba",
         "name": "La Habana",
         "region": "north_america",
-        "country": "cuba",
+        "country": "Cuba",
         "bbox": {
             "top": "23.184",
             "left": "-82.462",
@@ -1243,7 +1243,7 @@
         "id": "las-vegas_nevada",
         "name": "Las Vegas",
         "region": "north_america",
-        "country": "nevada",
+        "country": "United States",
         "bbox": {
             "top": "36.615",
             "left": "-115.581",
@@ -1255,7 +1255,7 @@
         "id": "los-angeles_california",
         "name": "Los Angeles",
         "region": "north_america",
-        "country": "california",
+        "country": "United States",
         "bbox": {
             "top": "34.583",
             "left": "-119.437",
@@ -1267,7 +1267,7 @@
         "id": "mexico-city_mexico",
         "name": "Mexico City",
         "region": "north_america",
-        "country": "mexico",
+        "country": "Mexico",
         "bbox": {
             "top": "19.921",
             "left": "-99.597",
@@ -1279,7 +1279,7 @@
         "id": "miami_florida",
         "name": "Miami",
         "region": "north_america",
-        "country": "florida",
+        "country": "United States",
         "bbox": {
             "top": "26.912",
             "left": "-80.683",
@@ -1291,7 +1291,7 @@
         "id": "minneapolis-saint-paul_minnesota",
         "name": "Minneapolis/Saint Paul",
         "region": "north_america",
-        "country": "minnesota",
+        "country": "United States",
         "bbox": {
             "top": "45.415",
             "left": "-94.013",
@@ -1303,7 +1303,7 @@
         "id": "montreal_canada",
         "name": "Montreal",
         "region": "north_america",
-        "country": "canada",
+        "country": "Canada",
         "bbox": {
             "top": "46.057",
             "left": "-74.734",
@@ -1315,7 +1315,7 @@
         "id": "nashville_tennessee",
         "name": "Nashville",
         "region": "north_america",
-        "country": "tennessee",
+        "country": "United States",
         "bbox": {
             "top": "36.652",
             "left": "-87.743",
@@ -1327,7 +1327,7 @@
         "id": "new-orleans_louisiana",
         "name": "New Orleans",
         "region": "north_america",
-        "country": "louisiana",
+        "country": "United States",
         "bbox": {
             "top": "30.510",
             "left": "-90.653",
@@ -1339,7 +1339,7 @@
         "id": "new-york_new-york",
         "name": "New York",
         "region": "north_america",
-        "country": "new-york",
+        "country": "United States",
         "bbox": {
             "top": "41.097",
             "left": "-74.501",
@@ -1351,7 +1351,7 @@
         "id": "ottawa_canada",
         "name": "Ottawa",
         "region": "north_america",
-        "country": "canada",
+        "country": "Canada",
         "bbox": {
             "top": "45.598",
             "left": "-76.361",
@@ -1363,7 +1363,7 @@
         "id": "philadelphia_pennsylvania",
         "name": "Philadelphia",
         "region": "north_america",
-        "country": "pennsylvania",
+        "country": "United States",
         "bbox": {
             "top": "40.308",
             "left": "-75.572",
@@ -1375,7 +1375,7 @@
         "id": "phoenix_arizona",
         "name": "Phoenix",
         "region": "north_america",
-        "country": "arizona",
+        "country": "United States",
         "bbox": {
             "top": "34.070",
             "left": "-112.821",
@@ -1387,7 +1387,7 @@
         "id": "pittsburgh_pennsylvania",
         "name": "Pittsburgh",
         "region": "north_america",
-        "country": "pennsylvania",
+        "country": "United States",
         "bbox": {
             "top": "40.880",
             "left": "-80.711",
@@ -1399,7 +1399,7 @@
         "id": "port-au-prince_haiti",
         "name": "Port au Prince",
         "region": "north_america",
-        "country": "haiti",
+        "country": "Haiti",
         "bbox": {
             "top": "18.683",
             "left": "-72.518",
@@ -1411,7 +1411,7 @@
         "id": "portland_oregon",
         "name": "Portland",
         "region": "north_america",
-        "country": "oregon",
+        "country": "United States",
         "bbox": {
             "top": "45.897",
             "left": "-123.521",
@@ -1423,7 +1423,7 @@
         "id": "raleigh_north-carolina",
         "name": "Raleigh",
         "region": "north_america",
-        "country": "north-carolina",
+        "country": "United States",
         "bbox": {
             "top": "36.051",
             "left": "-79.116",
@@ -1435,7 +1435,7 @@
         "id": "saint-louis_missouri",
         "name": "Saint Louis",
         "region": "north_america",
-        "country": "missouri",
+        "country": "United States",
         "bbox": {
             "top": "39.151",
             "left": "-91.010",
@@ -1447,7 +1447,7 @@
         "id": "san-antonio_texas",
         "name": "San Antonio",
         "region": "north_america",
-        "country": "texas",
+        "country": "United States",
         "bbox": {
             "top": "29.951",
             "left": "-98.951",
@@ -1459,7 +1459,7 @@
         "id": "san-diego-tijuana_mexico",
         "name": "San Diego/Tijuana",
         "region": "north_america",
-        "country": "mexico",
+        "country": "Mexico",
         "bbox": {
             "top": "33.078",
             "left": "-117.376",
@@ -1471,7 +1471,7 @@
         "id": "san-diego_california",
         "name": "San Diego",
         "region": "north_america",
-        "country": "california",
+        "country": "United States",
         "bbox": {
             "top": "32.910",
             "left": "-117.288",
@@ -1483,7 +1483,7 @@
         "id": "san-francisco-bay_california",
         "name": "San Francisco Bay",
         "region": "north_america",
-        "country": "california",
+        "country": "United States",
         "bbox": {
             "top": "38.719",
             "left": "-123.640",
@@ -1495,7 +1495,7 @@
         "id": "san-francisco_california",
         "name": "San Francisco",
         "region": "north_america",
-        "country": "california",
+        "country": "United States",
         "bbox": {
             "top": "37.955",
             "left": "-122.737",
@@ -1507,7 +1507,7 @@
         "id": "san-jose_california",
         "name": "San Jose",
         "region": "north_america",
-        "country": "california",
+        "country": "United States",
         "bbox": {
             "top": "37.469",
             "left": "-122.046",
@@ -1519,7 +1519,7 @@
         "id": "seattle_washington",
         "name": "Seattle",
         "region": "north_america",
-        "country": "washington",
+        "country": "United States",
         "bbox": {
             "top": "48.528",
             "left": "-123.931",
@@ -1531,7 +1531,7 @@
         "id": "tampa_florida",
         "name": "Tampa",
         "region": "north_america",
-        "country": "florida",
+        "country": "United States",
         "bbox": {
             "top": "28.376",
             "left": "-82.935",
@@ -1543,7 +1543,7 @@
         "id": "toronto_canada",
         "name": "Toronto",
         "region": "north_america",
-        "country": "canada",
+        "country": "Canada",
         "bbox": {
             "top": "44.182",
             "left": "-80.161",
@@ -1555,7 +1555,7 @@
         "id": "vancouver_canada",
         "name": "Vancouver",
         "region": "north_america",
-        "country": "canada",
+        "country": "Canada",
         "bbox": {
             "top": "49.320",
             "left": "-123.290",
@@ -1567,7 +1567,7 @@
         "id": "victoria_canada",
         "name": "Victoria",
         "region": "north_america",
-        "country": "canada",
+        "country": "Canada",
         "bbox": {
             "top": "48.871",
             "left": "-124.063",
@@ -1580,7 +1580,7 @@
         "id": "aarhus_denmark",
         "name": "Aarhus",
         "region": "northern_europe",
-        "country": "denmark",
+        "country": "Denmark",
         "bbox": {
             "top": "56.252",
             "left": "10.068",
@@ -1592,7 +1592,7 @@
         "id": "gothenburg_sweden",
         "name": "Gothenburg",
         "region": "northern_europe",
-        "country": "sweden",
+        "country": "Sweden",
         "bbox": {
             "top": "57.803",
             "left": "11.552",
@@ -1604,7 +1604,7 @@
         "id": "helsinki_finland",
         "name": "Helsinki",
         "region": "northern_europe",
-        "country": "finland",
+        "country": "Finland",
         "bbox": {
             "top": "60.680",
             "left": "24.340",
@@ -1616,7 +1616,7 @@
         "id": "oslo_norway",
         "name": "Oslo",
         "region": "northern_europe",
-        "country": "norway",
+        "country": "Norway",
         "bbox": {
             "top": "60.424",
             "left": "9.691",
@@ -1628,7 +1628,7 @@
         "id": "reykjavik_iceland",
         "name": "Reykjavik",
         "region": "northern_europe",
-        "country": "iceland",
+        "country": "Iceland",
         "bbox": {
             "top": "64.297",
             "left": "-22.826",
@@ -1640,7 +1640,7 @@
         "id": "stockholm_sweden",
         "name": "Stockholm",
         "region": "northern_europe",
-        "country": "sweden",
+        "country": "Sweden",
         "bbox": {
             "top": "60.249",
             "left": "16.858",
@@ -1653,7 +1653,7 @@
         "id": "adelaide_australia",
         "name": "Adelaide",
         "region": "oceania",
-        "country": "australia",
+        "country": "Australia",
         "bbox": {
             "top": "-34.570",
             "left": "138.417",
@@ -1665,7 +1665,7 @@
         "id": "auckland_new-zealand",
         "name": "Auckland",
         "region": "oceania",
-        "country": "new-zealand",
+        "country": "New Zealand",
         "bbox": {
             "top": "-36.410",
             "left": "174.223",
@@ -1677,7 +1677,7 @@
         "id": "bali_indonesia",
         "name": "Bali",
         "region": "oceania",
-        "country": "indonesia",
+        "country": "Indonesia",
         "bbox": {
             "top": "-6.995",
             "left": "113.055",
@@ -1689,7 +1689,7 @@
         "id": "bandung_indonesia",
         "name": "Bandung",
         "region": "oceania",
-        "country": "indonesia",
+        "country": "Indonesia",
         "bbox": {
             "top": "-6.773",
             "left": "107.474",
@@ -1701,7 +1701,7 @@
         "id": "brisbane_australia",
         "name": "Brisbane",
         "region": "oceania",
-        "country": "australia",
+        "country": "Australia",
         "bbox": {
             "top": "-27.000",
             "left": "152.700",
@@ -1713,7 +1713,7 @@
         "id": "jakarta_indonesia",
         "name": "Jakarta",
         "region": "oceania",
-        "country": "indonesia",
+        "country": "Indonesia",
         "bbox": {
             "top": "-5.881",
             "left": "106.435",
@@ -1725,7 +1725,7 @@
         "id": "melbourne_australia",
         "name": "Melbourne",
         "region": "oceania",
-        "country": "australia",
+        "country": "Australia",
         "bbox": {
             "top": "-37.365",
             "left": "144.266",
@@ -1737,7 +1737,7 @@
         "id": "perth_australia",
         "name": "Perth",
         "region": "oceania",
-        "country": "australia",
+        "country": "Australia",
         "bbox": {
             "top": "-31.705",
             "left": "115.439",
@@ -1749,7 +1749,7 @@
         "id": "sydney_australia",
         "name": "Sydney",
         "region": "oceania",
-        "country": "australia",
+        "country": "Australia",
         "bbox": {
             "top": "-33.637",
             "left": "150.628",
@@ -1762,7 +1762,7 @@
         "id": "bogota_colombia",
         "name": "Bogota",
         "region": "south_america",
-        "country": "colombia",
+        "country": "Colombia",
         "bbox": {
             "top": "5.022",
             "left": "-74.421",
@@ -1774,7 +1774,7 @@
         "id": "brasilia_brazil",
         "name": "Brasilia",
         "region": "south_america",
-        "country": "brazil",
+        "country": "Brazil",
         "bbox": {
             "top": "-15.360",
             "left": "-48.501",
@@ -1786,7 +1786,7 @@
         "id": "buenos-aires_argentina",
         "name": "Buenos Aires",
         "region": "south_america",
-        "country": "argentina",
+        "country": "Argentina",
         "bbox": {
             "top": "-34.219",
             "left": "-59.258",
@@ -1798,7 +1798,7 @@
         "id": "caracas_venezuela",
         "name": "Caracas",
         "region": "south_america",
-        "country": "venezuela",
+        "country": "Venezuela",
         "bbox": {
             "top": "10.645",
             "left": "-67.110",
@@ -1810,7 +1810,7 @@
         "id": "lima_peru",
         "name": "Lima",
         "region": "south_america",
-        "country": "peru",
+        "country": "Peru",
         "bbox": {
             "top": "-11.644",
             "left": "-77.294",
@@ -1822,7 +1822,7 @@
         "id": "medellin_colombia",
         "name": "Medellin",
         "region": "south_america",
-        "country": "colombia",
+        "country": "Colombia",
         "bbox": {
             "top": "6.497",
             "left": "-75.887",
@@ -1834,7 +1834,7 @@
         "id": "rio-de-janeiro_brazil",
         "name": "Rio de Janeiro",
         "region": "south_america",
-        "country": "brazil",
+        "country": "Brazil",
         "bbox": {
             "top": "-22.378",
             "left": "-43.860",
@@ -1846,7 +1846,7 @@
         "id": "santiago_chile",
         "name": "Santiago",
         "region": "south_america",
-        "country": "chile",
+        "country": "Chile",
         "bbox": {
             "top": "-33.151",
             "left": "-71.043",
@@ -1858,7 +1858,7 @@
         "id": "sao-paulo_brazil",
         "name": "Sao Paulo",
         "region": "south_america",
-        "country": "brazil",
+        "country": "Brazil",
         "bbox": {
             "top": "-23.125",
             "left": "-47.357",
@@ -1871,7 +1871,7 @@
         "id": "acoruna_spain",
         "name": "Acoruna",
         "region": "southern_europe",
-        "country": "spain",
+        "country": "Spain",
         "bbox": {
             "top": "43.600",
             "left": "-8.600",
@@ -1883,7 +1883,7 @@
         "id": "athens_greece",
         "name": "Athens",
         "region": "southern_europe",
-        "country": "greece",
+        "country": "Greece",
         "bbox": {
             "top": "38.365",
             "left": "22.949",
@@ -1895,7 +1895,7 @@
         "id": "barcelona_spain",
         "name": "Barcelona",
         "region": "southern_europe",
-        "country": "spain",
+        "country": "Spain",
         "bbox": {
             "top": "41.533",
             "left": "1.898",
@@ -1907,7 +1907,7 @@
         "id": "bologna_italy",
         "name": "Bologna",
         "region": "southern_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "44.668",
             "left": "10.998",
@@ -1919,7 +1919,7 @@
         "id": "florence_italy",
         "name": "Florence",
         "region": "southern_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "43.983",
             "left": "10.982",
@@ -1931,7 +1931,7 @@
         "id": "genoa_italy",
         "name": "Genoa",
         "region": "southern_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "44.561",
             "left": "8.444",
@@ -1943,7 +1943,7 @@
         "id": "lisbon_portugal",
         "name": "Lisbon",
         "region": "southern_europe",
-        "country": "portugal",
+        "country": "Portugal",
         "bbox": {
             "top": "39.150",
             "left": "-9.634",
@@ -1955,7 +1955,7 @@
         "id": "madrid_spain",
         "name": "Madrid",
         "region": "southern_europe",
-        "country": "spain",
+        "country": "Spain",
         "bbox": {
             "top": "41.030",
             "left": "-4.293",
@@ -1967,7 +1967,7 @@
         "id": "milan_italy",
         "name": "Milan",
         "region": "southern_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "45.694",
             "left": "8.860",
@@ -1979,7 +1979,7 @@
         "id": "naples_italy",
         "name": "Naples",
         "region": "southern_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "40.916",
             "left": "14.139",
@@ -1991,7 +1991,7 @@
         "id": "porto_portugal",
         "name": "Porto",
         "region": "southern_europe",
-        "country": "portugal",
+        "country": "Portugal",
         "bbox": {
             "top": "41.399",
             "left": "-8.795",
@@ -2003,7 +2003,7 @@
         "id": "rome_italy",
         "name": "Rome",
         "region": "southern_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "42.130",
             "left": "12.109",
@@ -2015,7 +2015,7 @@
         "id": "thessaloniki_greece",
         "name": "Thessaloniki",
         "region": "southern_europe",
-        "country": "greece",
+        "country": "Greece",
         "bbox": {
             "top": "40.656",
             "left": "22.902",
@@ -2027,7 +2027,7 @@
         "id": "valencia_spain",
         "name": "Valencia",
         "region": "southern_europe",
-        "country": "spain",
+        "country": "Spain",
         "bbox": {
             "top": "39.504",
             "left": "-0.436",
@@ -2039,7 +2039,7 @@
         "id": "venice_italy",
         "name": "Venice",
         "region": "southern_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "45.811",
             "left": "11.629",
@@ -2052,7 +2052,7 @@
         "id": "amsterdam_netherlands",
         "name": "Amsterdam",
         "region": "western_europe",
-        "country": "netherlands",
+        "country": "Netherlands",
         "bbox": {
             "top": "52.629",
             "left": "4.465",
@@ -2064,7 +2064,7 @@
         "id": "antwerp_belgium",
         "name": "Antwerp",
         "region": "western_europe",
-        "country": "belgium",
+        "country": "Belgium",
         "bbox": {
             "top": "51.385",
             "left": "4.192",
@@ -2076,7 +2076,7 @@
         "id": "belfast_ireland",
         "name": "Belfast",
         "region": "western_europe",
-        "country": "ireland",
+        "country": "Ireland",
         "bbox": {
             "top": "54.663",
             "left": "-6.046",
@@ -2088,7 +2088,7 @@
         "id": "berlin_germany",
         "name": "Berlin",
         "region": "western_europe",
-        "country": "germany",
+        "country": "Germany",
         "bbox": {
             "top": "52.994",
             "left": "12.260",
@@ -2100,7 +2100,7 @@
         "id": "bern_switzerland",
         "name": "Bern",
         "region": "western_europe",
-        "country": "switzerland",
+        "country": "Switzerland",
         "bbox": {
             "top": "47.023",
             "left": "7.330",
@@ -2112,7 +2112,7 @@
         "id": "birmingham_england",
         "name": "Birmingham",
         "region": "western_europe",
-        "country": "england",
+        "country": "England",
         "bbox": {
             "top": "52.794",
             "left": "-2.536",
@@ -2124,7 +2124,7 @@
         "id": "bordeaux_france",
         "name": "Bordeaux",
         "region": "western_europe",
-        "country": "france",
+        "country": "France",
         "bbox": {
             "top": "45.065",
             "left": "-0.900",
@@ -2136,7 +2136,7 @@
         "id": "brussels_belgium",
         "name": "Brussels",
         "region": "western_europe",
-        "country": "belgium",
+        "country": "Belgium",
         "bbox": {
             "top": "51.053",
             "left": "3.981",
@@ -2148,7 +2148,7 @@
         "id": "cardiff-newport-bristol-bath_england",
         "name": "Cardiff/Newport/Bristol/Bath",
         "region": "western_europe",
-        "country": "england",
+        "country": "England",
         "bbox": {
             "top": "51.730",
             "left": "-3.618",
@@ -2160,7 +2160,7 @@
         "id": "cologne_germany",
         "name": "Cologne",
         "region": "western_europe",
-        "country": "germany",
+        "country": "Germany",
         "bbox": {
             "top": "51.009",
             "left": "6.844",
@@ -2172,7 +2172,7 @@
         "id": "copenhagen_denmark",
         "name": "Copenhagen",
         "region": "western_europe",
-        "country": "denmark",
+        "country": "Denmark",
         "bbox": {
             "top": "55.950",
             "left": "11.894",
@@ -2184,7 +2184,7 @@
         "id": "dresden_germany",
         "name": "Dresden",
         "region": "western_europe",
-        "country": "germany",
+        "country": "Germany",
         "bbox": {
             "top": "51.180",
             "left": "13.586",
@@ -2196,7 +2196,7 @@
         "id": "dublin_ireland",
         "name": "Dublin",
         "region": "western_europe",
-        "country": "ireland",
+        "country": "Ireland",
         "bbox": {
             "top": "53.512",
             "left": "-6.569",
@@ -2208,7 +2208,7 @@
         "id": "duesseldorf_germany",
         "name": "Duesseldorf",
         "region": "western_europe",
-        "country": "germany",
+        "country": "Germany",
         "bbox": {
             "top": "51.361",
             "left": "6.622",
@@ -2220,7 +2220,7 @@
         "id": "edinburgh_scotland",
         "name": "Edinburgh",
         "region": "western_europe",
-        "country": "scotland",
+        "country": "Scotland",
         "bbox": {
             "top": "56.132",
             "left": "-3.585",
@@ -2232,7 +2232,7 @@
         "id": "frankfurt_germany",
         "name": "Frankfurt",
         "region": "western_europe",
-        "country": "germany",
+        "country": "Germany",
         "bbox": {
             "top": "50.227",
             "left": "8.471",
@@ -2244,7 +2244,7 @@
         "id": "glasgow_scotland",
         "name": "Glasgow",
         "region": "western_europe",
-        "country": "scotland",
+        "country": "Scotland",
         "bbox": {
             "top": "56.034",
             "left": "-4.613",
@@ -2256,7 +2256,7 @@
         "id": "hamburg_germany",
         "name": "Hamburg",
         "region": "western_europe",
-        "country": "germany",
+        "country": "Germany",
         "bbox": {
             "top": "53.833",
             "left": "9.376",
@@ -2268,7 +2268,7 @@
         "id": "liverpool_england",
         "name": "Liverpool",
         "region": "western_europe",
-        "country": "england",
+        "country": "England",
         "bbox": {
             "top": "53.514",
             "left": "-3.201",
@@ -2280,7 +2280,7 @@
         "id": "london_england",
         "name": "London",
         "region": "western_europe",
-        "country": "england",
+        "country": "England",
         "bbox": {
             "top": "51.984",
             "left": "-1.115",
@@ -2292,7 +2292,7 @@
         "id": "lyon_france",
         "name": "Lyon",
         "region": "western_europe",
-        "country": "france",
+        "country": "France",
         "bbox": {
             "top": "46.191",
             "left": "4.136",
@@ -2304,7 +2304,7 @@
         "id": "manchester_england",
         "name": "Manchester",
         "region": "western_europe",
-        "country": "england",
+        "country": "England",
         "bbox": {
             "top": "53.672",
             "left": "-2.588",
@@ -2316,7 +2316,7 @@
         "id": "marseille_france",
         "name": "Marseille",
         "region": "western_europe",
-        "country": "france",
+        "country": "France",
         "bbox": {
             "top": "43.554",
             "left": "4.905",
@@ -2328,7 +2328,7 @@
         "id": "munich_germany",
         "name": "Munich",
         "region": "western_europe",
-        "country": "germany",
+        "country": "Germany",
         "bbox": {
             "top": "48.248",
             "left": "11.359",
@@ -2340,7 +2340,7 @@
         "id": "paris_france",
         "name": "Paris",
         "region": "western_europe",
-        "country": "france",
+        "country": "France",
         "bbox": {
             "top": "49.178",
             "left": "1.851",
@@ -2352,7 +2352,7 @@
         "id": "rotterdam_netherlands",
         "name": "Rotterdam",
         "region": "western_europe",
-        "country": "netherlands",
+        "country": "Netherlands",
         "bbox": {
             "top": "52.109",
             "left": "3.911",
@@ -2364,7 +2364,7 @@
         "id": "southampton_england",
         "name": "Southampton",
         "region": "western_europe",
-        "country": "england",
+        "country": "England",
         "bbox": {
             "top": "50.956",
             "left": "-1.479",
@@ -2376,7 +2376,7 @@
         "id": "strasbourg_france",
         "name": "Strasbourg",
         "region": "western_europe",
-        "country": "france",
+        "country": "France",
         "bbox": {
             "top": "48.722",
             "left": "7.449",
@@ -2388,7 +2388,7 @@
         "id": "turin_italy",
         "name": "Turin",
         "region": "western_europe",
-        "country": "italy",
+        "country": "Italy",
         "bbox": {
             "top": "45.174",
             "left": "7.504",
@@ -2400,7 +2400,7 @@
         "id": "zurich_switzerland",
         "name": "Zurich",
         "region": "western_europe",
-        "country": "switzerland",
+        "country": "Switzerland",
         "bbox": {
             "top": "47.533",
             "left": "8.275",


### PR DESCRIPTION
* [x] Stop using S3 URL for GeoJSON.
* [x] Fix names and countries.
* [x] Generate `href` for metros.
* [x] Stop splitting on names in front-end code; use `display_name`, `id`, and `href`. Stop using `name` entirely; it’s deprecated.

Closes #68.