### PR TITLE
link organization and restyling

### DIFF
--- a/App/static/css/common.css
+++ b/App/static/css/common.css
@@ -30,3 +30,6 @@
   margin: 0 10px 10px 0;
   text-transform: uppercase;
 }
+.link:hover {
+  background: #eee;
+}

--- a/App/static/css/metro.css
+++ b/App/static/css/metro.css
@@ -5,11 +5,32 @@ h1 {
 }
 body.data-pages #map {
   width: 100%;
-  height: 500px;
   border: 1px solid #ddd;
+  margin-bottom: 100px;
+}
+#map, #map path {
+  cursor: default;
+}
+h2 {
+  margin-top: 0;
+}
+h3 {
+  font-size: 36px;
+  margin: 1.2em 0 .6em;
 }
 .btn-group {
   margin-bottom: 0px;
+}
+.dl-group {
+  margin-top: 10px;
+}
+.dl-group label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+#downloads p {
+  margin-top: 15px;
 }
 @media (max-width: 768px) {
   body.data-pages #map {

--- a/App/static/css/metros.css
+++ b/App/static/css/metros.css
@@ -11,7 +11,9 @@ body.data-pages .inline-submit .btn {
 body.data-pages .inline-submit .btn:hover { 
   background: #555; 
 }
-
+.map-wrapper {
+  padding: 0;
+}
 #map {
   border-right: 1px solid rgb(224,224,224);
 }
@@ -70,9 +72,6 @@ body.data-pages .inline-submit .btn:hover {
   color: #000;
   font-weight: normal;
   display: block;
-}
-.city:hover {
-  text-decoration: underline;
 }
 #did-you-mean {
   display: none;

--- a/App/static/js/extract.js
+++ b/App/static/js/extract.js
@@ -21,9 +21,9 @@ var Extract = function (){
         northeast = L.latLng(bbox.n, bbox.e),
         options = {
           scrollWheelZoom: false,
-          // Disables dragging on touch-detected devices
-          dragging: (window.self !== window.top && L.Browser.touch) ? false : true,
-          tap: (window.self !== window.top && L.Browser.touch) ? false : true,
+          zoomControl:false,
+          dragging: false,
+          tap: false
         };
       displayMap = L.map('map', options).fitBounds(L.latLngBounds(southwest, northeast));
 

--- a/App/static/js/metro.js
+++ b/App/static/js/metro.js
@@ -22,11 +22,11 @@ var Metro = function (){
         northeast = L.latLng(metro.bbox.top, metro.bbox.left),
         options = {
           scrollWheelZoom: false,
-          // Disables dragging on touch-detected devices
-          dragging: (window.self !== window.top && L.Browser.touch) ? false : true,
-          tap: (window.self !== window.top && L.Browser.touch) ? false : true,
+          zoomControl:false,
+          dragging: false,
+          tap: false
         };
-      displayMap = L.map('map', options).fitBounds(L.latLngBounds(southwest, northeast));
+      displayMap = L.map('map', options).fitBounds(L.latLngBounds(southwest, northeast)).zoomOut(1);
 
       if (this.hasWebGL() === true) {
         var layer = Tangram.leafletLayer({
@@ -40,7 +40,7 @@ var Metro = function (){
       }
       layer.addTo(displayMap);
 
-      var rect = new L.Rectangle(new L.LatLngBounds([southwest, northeast]), { className : "blue" });
+      var rect = new L.Rectangle(new L.LatLngBounds([southwest, northeast]));
       displayMap.addLayer(rect);
     }
   };

--- a/App/static/js/metro.js
+++ b/App/static/js/metro.js
@@ -26,7 +26,7 @@ var Metro = function (){
           dragging: false,
           tap: false
         };
-      displayMap = L.map('map', options).fitBounds(L.latLngBounds(southwest, northeast)).zoomOut(1);
+      displayMap = L.map('map', options).fitBounds(L.latLngBounds(southwest, northeast));
 
       if (this.hasWebGL() === true) {
         var layer = Tangram.leafletLayer({

--- a/App/templates/email-body.html
+++ b/App/templates/email-body.html
@@ -143,7 +143,7 @@ p {
               <h1>metro extracts</h1>
               <p>Hooray, the metro extract that you requested at {{ created }} has finished.</p>
               <a href="{{ link }}" class="btn">View {{ name }}</a>
-              <p>If you have any questions, please get in touch with us at <a href="mailto:support@mapzen.com">support@mapzen.com</a>
+              <p>If you have any questions, please get in touch with us at <a href="mailto:hello@mapzen.com">hello@mapzen.com</a>
               <p>
                 <a href="{{ extracts_link }}">Previous Requests</a> |
                 <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> |

--- a/App/templates/email-body.txt
+++ b/App/templates/email-body.txt
@@ -2,4 +2,4 @@ Hooray, your requested extract for {{ name }} at {{ created }} has finished.
 
 You can download it here: {{ link }}
 
-If you have any questions, please get in touch with us at support@mapzen.com.
+If you have any questions, please get in touch with us at hello@mapzen.com.

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -17,7 +17,7 @@
       <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
     </p>
     <div class='row inline-submit' id='search-box'>
-      <label class='data-filter-label' for='search_input'>Filter Extracts by City or Region</label>
+      <label class='data-filter-label' for='search_input'>Search for a City or Region</label>
       <input type='search' class='hasclear col-sm-9 col-xs-8' id='search_input' placeholder='example: Los Angeles' type='text'>
       <input id='search_submit' type="submit" value="search" class="col-xs-4 col-sm-3 btn btn-transparent">
       <div class="autocomplete"></div>

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -5,52 +5,50 @@
 {% endblock %}
 
 {% block content %}
-  <div class='container-fluid'>
-    <div class='col-xs-12 col-sm-6'>
-      <div id='map'></div>
+  <div class='col-xs-12 col-sm-6 map-wrapper'>
+    <div id='map'></div>
+  </div>
+  <div class='col-xs-12 col-sm-6'>
+    <h1 class="headroom text-center">metro extracts</h1>
+    <p>Now it’s even easier to get local data so you can start building cool stuff. Each week, we automatically extract the latest <a href='http://openstreetmap.org/'>OpenStreetMap</a> data into manageable, metro-area shapefiles in a variety of formats for you to use.</p>
+    <p>
+      <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> |
+      <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> |
+      <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
+    </p>
+    <div class='row inline-submit' id='search-box'>
+      <label class='data-filter-label' for='search_input'>Filter Extracts by City or Region</label>
+      <input type='search' class='hasclear col-sm-9 col-xs-8' id='search_input' placeholder='example: Los Angeles' type='text'>
+      <input id='search_submit' type="submit" value="search" class="col-xs-4 col-sm-3 btn btn-transparent">
+      <div class="autocomplete"></div>
     </div>
-    <div class='col-xs-12 col-sm-6'>
-      <h1 class="headroom text-center">metro extracts</h1>
-      <p>Now it’s even easier to get local data so you can start building cool stuff. Each week, we automatically extract the latest <a href='http://openstreetmap.org/'>OpenStreetMap</a> data into manageable, metro-area shapefiles in a variety of formats for you to use.</p>
-      <p>
-        <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> |
-        <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> |
-        <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
-      </p>
-      <div class='row inline-submit' id='search-box'>
-        <label class='data-filter-label' for='search_input'>Filter Extracts by City or Region</label>
-        <input type='search' class='hasclear col-sm-9 col-xs-8' id='search_input' placeholder='example: Los Angeles' type='text'>
-        <input id='search_submit' type="submit" value="search" class="col-xs-4 col-sm-3 btn btn-transparent">
-        <div class="autocomplete"></div>
+    <div id="request-wrapper">
+      <p id="did-you-mean" class="request-messaging">Did you mean <span class="name"></span>?</p>
+      <p class="encompassed-text request-messaging">Your extract is included inside of a larger area: </p>
+      <div id="extracts">
+        {% for country_metros in metros_tree %}
+          <div class="country">
+            <div class="country-name">{{ country_metros.country }}</div>
+            {% for metro in country_metros.metros %}
+              <a class="city" href="{{ metro.href }}">{{ metro.name }}</a>
+            {% endfor %}
+          </div>
+        {% endfor %}
       </div>
-      <div id="request-wrapper">
-        <p id="did-you-mean" class="request-messaging">Did you mean <span class="name"></span>?</p>
-        <p class="encompassed-text request-messaging">Your extract is included inside of a larger area: </p>
-        <div id="extracts">
-          {% for country_metros in metros_tree %}
-            <div class="country">
-              <div class="country-name">{{ country_metros.country }}</div>
-              {% for metro in country_metros.metros %}
-                <a class="city" href="{{ metro.href }}">{{ metro.name }}</a>
-              {% endfor %}
-            </div>
-          {% endfor %}
-        </div>
-        <div id="make-request">
-          <p class="default-request-text request-messaging">Hmm, we don't have an extract for <span class="name"></span> yet. Would you like to request one?</p>
-          <p class="encompassed-text request-messaging">If you'd like to request an extract specifically for <span class="name"></span>, click the button below. Please note, this can take a few hours to process.</p>
-          <p class="request-greater-1 request-messaging">We don't have a request for <span class="name"></span> yet, you can request one by clicking the button below. Please note, you have requested a large area and this request will take more than a few hours to process.</p>
-          <p class="request-greater-5 request-messaging">Sorry, but your request for <span class="name"></span> is too large to prcoess. Please make your request a smaller area.</p>
-          <form action="{{ url_for('ODES.post_envelope') }}" method="post">
-            <input name="bbox_n" type="hidden" />
-            <input name="bbox_w" type="hidden" />
-            <input name="bbox_s" type="hidden" />
-            <input name="bbox_e" type="hidden" />
-            <input name="wof_id" type="hidden" />
-            <input name="wof_name" type="hidden" />
-            <button class="btn btn-transparent">Create <span class="name"></span> Request</button>
-          </form>
-        </div>
+      <div id="make-request">
+        <p class="default-request-text request-messaging">Hmm, we don't have an extract for <span class="name"></span> yet. Would you like to request one?</p>
+        <p class="encompassed-text request-messaging">If you'd like to request an extract specifically for <span class="name"></span>, click the button below. Please note, this can take a few hours to process.</p>
+        <p class="request-greater-1 request-messaging">We don't have a request for <span class="name"></span> yet, you can request one by clicking the button below. Please note, you have requested a large area and this request will take more than a few hours to process.</p>
+        <p class="request-greater-5 request-messaging">Sorry, but your request for <span class="name"></span> is too large to prcoess. Please make your request a smaller area.</p>
+        <form action="{{ url_for('ODES.post_envelope') }}" method="post">
+          <input name="bbox_n" type="hidden" />
+          <input name="bbox_w" type="hidden" />
+          <input name="bbox_s" type="hidden" />
+          <input name="bbox_e" type="hidden" />
+          <input name="wof_id" type="hidden" />
+          <input name="wof_name" type="hidden" />
+          <button class="btn btn-transparent">Create <span class="name"></span> Request</button>
+        </form>
       </div>
     </div>
   </div>

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -5,49 +5,57 @@
 {% endblock %}
 
 {% block content %}
-  <div class="container-fluid">
-    <div class="col-xs-12">
-      <ol class="breadcrumb">
-        <li>
-          <a href="{{ url_for('Metro-Extracts.index') }}">Metro Extracts</a>
-        </li>
-        <li class="active">{{ metro.name }}</li>
-      </ol>
+  <div class="col-xs-12">
+    <ol class="breadcrumb">
+      <li>
+        <a href="{{ url_for('Metro-Extracts.index') }}">Metro Extracts</a>
+      </li>
+      <li class="active">{{ metro.name }}</li>
+    </ol>
+  </div>
+  <div class="col-sm-6 col-xs-12">
+    <div id="map"></div>
+  </div>
+  <div class="col-sm-6 col-xs-12">
+    <h2>{{ metro.name }}</h2>
+    <div class="btn-group" style="margin: 0 auto;">
+      <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> | 
+      <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> | 
+      <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
     </div>
-    <div class="col-xs-12">
-      <h1>Metro Extract: {{ metro.name }}</h1>
-    </div>
-    <div class="col-sm-6 col-xs-12">
-      <div id="map"></div>
-    </div>
-    <div class="col-sm-6 col-xs-12">
-      <div class="btn-group">
-        <a class="btn btn-transparent" href="https://mapzen.com/documentation/metro-extracts/">Documentation</a>
-        <a class="btn btn-transparent" href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a>
-        <a class="btn btn-transparent" href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
-      </div>
-      <h2>Downloads</h2>
-      <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
-      <div id="downloads">
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.pbf">OSM PBF</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.xml">OSM XML</a>
+    <h3>Downloads</h3>
+    <div id="downloads">
+      <div class="dl-group">
+        <label>Points, Lines, and Polygons</label>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-shapefiles.zip">OSM2PGSQL SHP</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-geojson.zip">OSM2PGSQL GEOJSON</a>
+      </div>
+      <div class="dl-group">
+        <label>Layers (buildings, roads, etc)</label>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-shapefiles.zip">IMPOSM SHP</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-geojson.zip">IMPOSM GEOJSON</a>
+      </div>
+      <div class="dl-group">
+        <label>OpenStreetMap-specific Formats</label>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.pbf">OSM PBF</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.xml">OSM XML</a>
+      </div>
+      <div class="dl-group">
+        <label>Coastlines</label>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.water.coastline.zip">WATER COASTLINE SHP</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.land.coastline.zip">LAND COASTLINE SHP</a>
       </div>
-      {% if wof_id and wof_name %}
-      <div id="encompassed">
-        <p>If you'd like to clip this extract to just {{wof_name}}, please use this outline:</p>
-        <a class="link" href="{{ url_for('Metro-Extracts.wof_geojson', id=wof_id)}}">{{wof_name}} GEOJSON</a>
-      </div>
-      {% endif %}
-      <h2>About</h2>
-      <p>Mapzen Metro Extracts are produced via a <a href="https://github.com/mapzen/chef-metroextractor">chef cookbook</a> derived from the work of <a href="http://metro.teczno.com">Michal Migurski</a>.</p>
-      <p>For more granular OpenStreetMap data, we offer a free, hosted <a href="https://mapzen.com/documentation/vector-tiles/">Vector Tile service</a> — sign up for your <a href="https://mapzen.com/developers/">API key here</a>.</p>
+      <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
     </div>
+    {% if wof_id and wof_name %}
+    <div id="encompassed">
+      <p>If you'd like to clip this extract to just {{wof_name}}, please use this outline:</p>
+      <a class="link" href="{{ url_for('Metro-Extracts.wof_geojson', id=wof_id)}}">{{wof_name}} GEOJSON</a>
+    </div>
+    {% endif %}
+    <h3>About</h3>
+    <p>Mapzen Metro Extracts are produced via a <a href="https://github.com/mapzen/chef-metroextractor">chef cookbook</a> derived from the work of <a href="http://metro.teczno.com">Michal Migurski</a>.</p>
+    <p>For more granular OpenStreetMap data, we offer a free, hosted <a href="https://mapzen.com/documentation/vector-tiles/">Vector Tile service</a>. <b>Sign up for your free <a href="https://mapzen.com/developers/">API key here</a>.</b></p>
   </div>
 {% endblock %}
 
@@ -56,6 +64,9 @@
 {% endblock %}
 
 {% block script %}
+  var mapHeight = window.innerWidth < 768 ? 300 : window.innerHeight - 114;
+  d3.select("#map").style("height", mapHeight + 'px');
+
   var metro = {{metro|tojson|safe}},
     sceneURL = "{{ url_for('static', filename='scene.yaml') }}";
 

--- a/App/templates/odes/extract.html
+++ b/App/templates/odes/extract.html
@@ -5,40 +5,36 @@
 {% endblock %}
 
 {% block content %}
-  <div class="container-fluid">
-    <div class="col-xs-12">
-      <ol class="breadcrumb">
-        <li>
-          <a href="{{ url_for('Metro-Extracts.index') }}">Metro Extracts</a>
-        </li>
-        <li>
-          <a href="{{ url_for('ODES.get_extracts') }}">Requested Extracts</a>
-        </li>
-        <li class="active">{{extract.wof.name or extract.id or extract.odes.id}}</li>
-      </ol>
+  <div class="col-xs-12">
+    <ol class="breadcrumb">
+      <li>
+        <a href="{{ url_for('Metro-Extracts.index') }}">Metro Extracts</a>
+      </li>
+      <li>
+        <a href="{{ url_for('ODES.get_extracts') }}">Requested Extracts</a>
+      </li>
+      <li class="active">{{extract.wof.name or extract.id or extract.odes.id}}</li>
+    </ol>
+  </div>
+  <div class="col-sm-6 col-xs-12">
+    <div id="map"></div>
+  </div>
+  <div class="col-sm-6 col-xs-12">
+    <h2>Requested Extract: {{extract.wof.name or extract.id or extract.odes.id}}</h2>
+    <div class="btn-group" style="margin: 0 auto;">
+      <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> | 
+      <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> | 
+      <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
     </div>
-    <div class="col-xs-12 text-center">
-      <h1>Requested Extract: {{extract.wof.name or extract.id or extract.odes.id}}</h1>
-    </div>
-    <div class="col-sm-6 col-xs-12">
-      <div id="map"></div>
-    </div>
-    <div class="col-sm-6 col-xs-12">
-      <div class="btn-group">
-        <a class="btn btn-transparent" href="https://mapzen.com/documentation/metro-extracts/">Documentation</a>
-        <a class="btn btn-transparent" href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a>
-        <a class="btn btn-transparent" href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
-      </div>
-      <h2>Downloads</h2>
-      <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
-      {% for (name, href) in extract.odes.links.items() %}
-          <a class="link" href="{{href}}">{{name}}</a>
-      {% endfor %}
+    <h3>Downloads</h3>
+    {% for (name, href) in extract.odes.links.items() %}
+        <a class="link" href="{{href}}">{{name}}</a>
+    {% endfor %}
+    <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
 
-      <h2>About</h2>
-      <p>Mapzen Metro Extracts are produced via a <a href="https://github.com/mapzen/chef-metroextractor">chef cookbook</a> derived from the work of <a href="http://metro.teczno.com">Michal Migurski</a>.</p>
-      <p>For more granular OpenStreetMap data, we offer a free, hosted <a href="https://mapzen.com/documentation/vector-tiles/">Vector Tile service</a> — sign up for your <a href="https://mapzen.com/developers/">API key here</a>.</p>
-    </div>
+    <h3>About</h3>
+    <p>Mapzen Metro Extracts are produced via a <a href="https://github.com/mapzen/chef-metroextractor">chef cookbook</a> derived from the work of <a href="http://metro.teczno.com">Michal Migurski</a>.</p>
+    <p>For more granular OpenStreetMap data, we offer a free, hosted <a href="https://mapzen.com/documentation/vector-tiles/">Vector Tile service</a>. <b>Sign up for your free <a href="https://mapzen.com/developers/">API key here</a>.</b></p>
   </div>
 
 {% endblock %}
@@ -48,6 +44,9 @@
 {% endblock %}
 
 {% block script %}
+  var mapHeight = window.innerWidth < 768 ? 300 : window.innerHeight - 114;
+  d3.select("#map").style("height", mapHeight + 'px');
+
   var extractPage = Extract().init(
     {{ extract.odes.bbox|safe }}, 
     "{{ url_for('static', filename='scene.yaml') }}"

--- a/test.py
+++ b/test.py
@@ -110,7 +110,7 @@ class TestApp (unittest.TestCase):
         link1 = soup1.find_all(text='San Francisco')[0].find_parent('a')
         resp2 = self.client.get(link1['href'])
         soup2 = BeautifulSoup(resp2.data, 'html.parser')
-        head2 = soup2.find('h1').text
+        head2 = soup2.find('h2').text
 
         self.assertEqual(resp2.status_code, 200)
         self.assertIn('San Francisco', head2)


### PR DESCRIPTION
closes #90 

![screen shot 2016-07-06 at 11 56 49 am](https://cloud.githubusercontent.com/assets/589151/16630813/d7e440a8-4370-11e6-9b7c-478654a48142.png)
front page: not much different, just full-width map, new search box text, and no underline on hover for cities

![screen shot 2016-07-06 at 11 39 59 am](https://cloud.githubusercontent.com/assets/589151/16630831/e80a4a40-4370-11e6-87e3-c5a65541419a.png)
metro page: link organization, changing the extract to be red for the "existing extract" color, removing the h1

![screen shot 2016-07-06 at 11 54 55 am](https://cloud.githubusercontent.com/assets/589151/16630857/ff3598e6-4370-11e6-8419-ca53f69d8301.png)
following the same format as the metro

@migurski is it possible to have the extract links go to specific locations (so we could have the labels/grouping) or does it need to be a for loop?
