### PR TITLE
a buncha upgrades

### DIFF
--- a/App/static/css/common.css
+++ b/App/static/css/common.css
@@ -1,6 +1,17 @@
 .col-sm-6 {
   margin-bottom: 100px;
 }
+.legend-red {
+  background: rgba(212,100,92,.3);
+  padding: 0 5px;
+}
+.legend-blue {
+  background: rgba(110,160,164,.3);
+  padding: 0 5px;
+}
+#map {
+  overflow: hidden;
+}
 #map path, .map path {
   fill: #d4645c;
   stroke: #d4645c;
@@ -8,16 +19,23 @@
   stroke-opacity: .3;
   fill-opacity: .3;
 }
+#map.request-mode path.red {
+  fill: transparent;
+  stroke-opacity: .9;
+  stroke-width: 3;
+}
 #map path.blue, .map path.blue {
   fill: #6ea0a4;
   stroke: #6ea0a4;
   fill-opacity: .4;
+  cursor: default;
 }
 #map path.outline {
   stroke: #000;
   fill: #6ea0a4;
   fill-opacity: .3;
   stroke-opacity: .5;
+  cursor: default;
 }
 .leaflet-container a {
   color: #6ea0a4;

--- a/App/static/css/metro.css
+++ b/App/static/css/metro.css
@@ -12,16 +12,24 @@ h3 {
   font-size: 36px;
   margin: 1.2em 0 .6em;
 }
+p.error {
+  color: #d4645c;
+}
 .btn-group {
   margin-bottom: 0px;
 }
 .dl-group {
   margin-top: 10px;
 }
+.dl-group .label,
 .dl-group label {
   display: block;
   font-weight: bold;
   margin-bottom: 5px;
+  color: #000;
+}
+.dl-group .label:hover {
+  text-decoration: underline;
 }
 #downloads p {
   margin-top: 15px;

--- a/App/static/css/metros.css
+++ b/App/static/css/metros.css
@@ -72,6 +72,7 @@ body.data-pages .inline-submit .btn:hover {
   color: #000;
   font-weight: normal;
   display: block;
+  text-transform: capitalize;
 }
 #search-error .name {
   font-weight: bold;
@@ -122,6 +123,10 @@ body.data-pages .inline-submit .btn:hover {
   padding: 1px 0 1px 15px;
   color: #808080;
   cursor: pointer;
+}
+.suggestion .layer {
+  float: right;
+  text-align: right;
 }
 .suggestion.selected {
   color: #000;

--- a/App/static/js/extract.js
+++ b/App/static/js/extract.js
@@ -25,7 +25,7 @@ var Extract = function (){
           dragging: false,
           tap: false
         };
-      displayMap = L.map('map', options).fitBounds(L.latLngBounds(southwest, northeast));
+      displayMap = L.map('map', options).fitBounds(L.latLngBounds(southwest, northeast)).zoomOut(1);
 
       if (this.hasWebGL() === true) {
         var layer = Tangram.leafletLayer({

--- a/App/static/js/metro.js
+++ b/App/static/js/metro.js
@@ -8,8 +8,9 @@ var Metro = function (){
       metro = data;
       sceneURL = URL;
       this.initDisplayMap();
+      return this;
     },
-    hasWebGL: function() {
+    hasWebGL : function() {
       try {
         var canvas = document.createElement('canvas')
         return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')))
@@ -17,7 +18,7 @@ var Metro = function (){
         return false
       }
     },
-    initDisplayMap: function() {
+    initDisplayMap : function() {
       var southwest = L.latLng(metro.bbox.bottom, metro.bbox.right),
         northeast = L.latLng(metro.bbox.top, metro.bbox.left),
         options = {
@@ -42,6 +43,12 @@ var Metro = function (){
 
       var rect = new L.Rectangle(new L.LatLngBounds([southwest, northeast]));
       displayMap.addLayer(rect);
+    },
+    showOutline : function(wof_id) {
+      d3.json("/wof/"+wof_id+".geojson",function(data){
+        outline = L.geoJson(data.geometry, { className : "outline" }).addTo(displayMap);
+        displayMap.addLayer(outline);
+      });
     }
   };
   return MetroApp;

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -10,8 +10,9 @@
   </div>
   <div class='col-xs-12 col-sm-6'>
     <h1 class="headroom text-center">metro extracts</h1>
-    <p>Now it’s even easier to get local data so you can start building cool stuff. Each week, we automatically extract the latest <a href='http://openstreetmap.org/'>OpenStreetMap</a> data into manageable, metro-area shapefiles in a variety of formats for you to use.</p>
-    <p>
+    <p>Each week, Metro Extracts automatically extracts the latest <a href='http://openstreetmap.org/'>OpenStreetMap</a> data into manageable, metro-area files in a variety of formats for you to use. Download an existing extracts to get started right away, or request a new extract of anywhere in the world!</p>
+    <p>The <span class="legend-red">red</span> boxes represent existing extracts, while the <span class="legend-blue">blue</span> ones are new requests.</p>
+    <p class="text-center">
       <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> |
       <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> |
       <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
@@ -38,7 +39,8 @@
       <div id="make-request">
         <p class="default-request-text request-messaging">Hmm, we don't have an extract for <span class="name"></span> yet. Would you like to request one?</p>
         <p class="encompassed-text request-messaging">If you'd like to request an extract specifically for <span class="name"></span>, click the button below. Please note, this can take a few hours to process.</p>
-        <p class="request-greater-1 request-messaging">We don't have a request for <span class="name"></span> yet, you can request one by clicking the button below. Please note, you have requested a large area and this request will take more than a few hours to process.</p>
+        <p class="request-greater-1 request-messaging">We don't have a request for <span class="name"></span> yet, but you can request one by clicking the button below. Please note, you have requested a large area and this request will take more than a few hours to process.</p>
+        <p class="request-greater-1 encompassed-text default-request-text request-messaging">Feel free to drag the corners of the box on the map to adjust the size of your request.</p>
         <p class="request-greater-5 request-messaging">Sorry, but your request for <span class="name"></span> is too large to prcoess. Please make your request a smaller area.</p>
         <form action="{{ url_for('ODES.post_envelope') }}" method="post">
           <input name="bbox_n" type="hidden" />
@@ -70,7 +72,7 @@
 
   d3.selectAll(".country-name")
     .on("click",function(d){
-      metrosPage.doSearch(d3.select(this).text());
+      metrosPage.doSearch(d3.select(this).text(), true);
     });
 
   d3.select("#search_submit").on("click",function(){

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -23,36 +23,39 @@
       <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> | 
       <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
     </div>
+
+    {% if wof_id and wof_name %}
+      <div id="encompassed">
+        <h3>{{ wof_name }}</h3>
+        <p>To clip this extract to the <span class="legend-blue">{{wof_name}} boundary</span>, use this outline:</p>
+        <a class="link" href="{{ url_for('Metro-Extracts.wof_geojson', id=wof_id)}}">{{wof_name}}  GEOJSON</a>
+      </div>
+    {% endif %}
+
     <h3>Downloads</h3>
     <div id="downloads">
       <div class="dl-group">
-        <label>Points, Lines, and Polygons</label>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-shapefiles.zip">OSM2PGSQL SHP</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-geojson.zip">OSM2PGSQL GEOJSON</a>
+        <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">Points, Lines, and Polygons (OSM2PGSQL)</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-shapefiles.zip">SHAPEFILE</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-geojson.zip">GEOJSON</a>
       </div>
       <div class="dl-group">
-        <label>Layers (buildings, roads, etc)</label>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-shapefiles.zip">IMPOSM SHP</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-geojson.zip">IMPOSM GEOJSON</a>
+        <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">Layers (buildings, roads, etc) (IMPOSM)</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-shapefiles.zip">SHAPEFILE</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-geojson.zip">GEOJSON</a>
       </div>
       <div class="dl-group">
-        <label>OpenStreetMap-specific Formats</label>
+        <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">OpenStreetMap-specific Formats</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.pbf">OSM PBF</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.xml">OSM XML</a>
       </div>
       <div class="dl-group">
         <label>Coastlines</label>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.water.coastline.zip">WATER COASTLINE SHP</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.land.coastline.zip">LAND COASTLINE SHP</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.water.coastline.zip">WATER COASTLINE SHAPEFILE</a>
+        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.land.coastline.zip">LAND COASTLINE SHAPEFILE</a>
       </div>
       <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
     </div>
-    {% if wof_id and wof_name %}
-    <div id="encompassed">
-      <p>If you'd like to clip this extract to just {{wof_name}}, please use this outline:</p>
-      <a class="link" href="{{ url_for('Metro-Extracts.wof_geojson', id=wof_id)}}">{{wof_name}} GEOJSON</a>
-    </div>
-    {% endif %}
     <h3>About</h3>
     <p>Mapzen Metro Extracts are produced via a <a href="https://github.com/mapzen/chef-metroextractor">chef cookbook</a> derived from the work of <a href="http://metro.teczno.com">Michal Migurski</a>.</p>
     <p>For more granular OpenStreetMap data, we offer a free, hosted <a href="https://mapzen.com/documentation/vector-tiles/">Vector Tile service</a>. <b>Sign up for your free <a href="https://mapzen.com/developers/">API key here</a>.</b></p>
@@ -72,7 +75,7 @@
 
   var metroPage = Metro().init(metro, sceneURL);
 
-  if (window.location.search)
-    metroPage.addEnclosed(window.location.search.split("?")[1]);
+  if ({{wof_id}} && "{{wof_name}}")
+    metroPage.showOutline({{wof_id}});
 
 {% endblock %}

--- a/App/templates/odes/extract.html
+++ b/App/templates/odes/extract.html
@@ -20,17 +20,24 @@
     <div id="map"></div>
   </div>
   <div class="col-sm-6 col-xs-12">
-    <h2>Requested Extract: {{extract.wof.name or extract.id or extract.odes.id}}</h2>
+    <h2>{{extract.wof.name or extract.id or extract.odes.id}}</h2>
     <div class="btn-group" style="margin: 0 auto;">
       <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> | 
       <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> | 
       <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
     </div>
     <h3>Downloads</h3>
-    {% for (name, href) in extract.odes.links.items() %}
-        <a class="link" href="{{href}}">{{name}}</a>
-    {% endfor %}
-    <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
+    {% if extract.odes.status == "pending" or extract.odes.status == "processing" %}
+      <p class="error">Sit tight! Your extract will take a little while to process, depending on the size of the area that you requested.</p>
+      <p class="error">Your download links will appear on this page once it has finished processing. We will also email you a link to this page, so feel free to close this page and come back to it later!</p>
+    {% elif extract.odes.status == "errored" %}
+      <p class="error">Oh no, your extract request seems to have errored out. Please let us know at <a href="mailto:hello@mapzen.com">hello@mapzen.com</a>.</p>
+    {% else %}
+      {% for (name, href) in extract.odes.links.items() %}
+          <a class="link" href="{{href}}">{{name}}</a>
+      {% endfor %}
+      <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
+    {% endif %}
 
     <h3>About</h3>
     <p>Mapzen Metro Extracts are produced via a <a href="https://github.com/mapzen/chef-metroextractor">chef cookbook</a> derived from the work of <a href="http://metro.teczno.com">Michal Migurski</a>.</p>


### PR DESCRIPTION
index:
* rewrite top text to not say shapefile and just a variety of formats
* showing layer info in autocomplete suggestions so that places with the same name but diff locality or neighborhood are more obvious
* click on autocomplete suggestion puts text in search box
* map key for red and blue boxes
* taking out red boxes in "request mode" so they are outlines but not fill, this eases up the blood map
* adding text for drag to adjust request box size
* fix bug on clicking country name
* click country name farther down on page filters map and scrolls one up to the top of the page

metro:
* move clipping box up to top of page
* if encompassed area, show the city outline on the page
* adjust zoom scale between request and metro page
* reorganizing download links to move creation tool out of the name, and links to documentation per type

extract:
* error handling and messaging for "your extract is being processed"