### PR TITLE
ux upgrades

### DIFF
--- a/App/static/css/metro.css
+++ b/App/static/css/metro.css
@@ -15,20 +15,16 @@ h3 {
 p.error {
   color: #d4645c;
 }
-.btn-group {
-  margin-bottom: 0px;
-}
-.dl-group {
+#downloads .label,
+#downloads label {
   margin-top: 10px;
-}
-.dl-group .label,
-.dl-group label {
-  display: block;
+  display: inline-block;
+  clear: both;
   font-weight: bold;
   margin-bottom: 5px;
   color: #000;
 }
-.dl-group .label:hover {
+#downloads .label:hover {
   text-decoration: underline;
 }
 #downloads p {

--- a/App/static/css/metros.css
+++ b/App/static/css/metros.css
@@ -127,6 +127,7 @@ body.data-pages .inline-submit .btn:hover {
 .suggestion .layer {
   float: right;
   text-align: right;
+  padding-right: 10px;
 }
 .suggestion.selected {
   color: #000;

--- a/App/static/js/extract.js
+++ b/App/static/js/extract.js
@@ -21,7 +21,8 @@ var Extract = function (){
         northeast = L.latLng(bbox.n, bbox.e),
         options = {
           scrollWheelZoom: false,
-          zoomControl:false,
+          zoomControl: false,
+          doubleClickZoom: false,
           dragging: false,
           tap: false
         };

--- a/App/static/js/metro.js
+++ b/App/static/js/metro.js
@@ -23,7 +23,8 @@ var Metro = function (){
         northeast = L.latLng(metro.bbox.top, metro.bbox.left),
         options = {
           scrollWheelZoom: false,
-          zoomControl:false,
+          zoomControl: false,
+          doubleClickZoom: false,
           dragging: false,
           tap: false
         };

--- a/App/static/js/metros.js
+++ b/App/static/js/metros.js
@@ -203,6 +203,7 @@ var Metros = function() {
             m.filterList(query);
             window.scroll(0,0);
           } else {
+            m.zoomMap(json.features[0].bbox);
             m.clearRequest();
           }
         });
@@ -224,7 +225,7 @@ var Metros = function() {
       requestBoundingBox = this.calculateNewBox(bbox);
 
       this.drawRequestBox();
-      d3.select("#map").attr("class","request-mode");
+      d3.select("#map").classed("request-mode",true);
 
       if (metro.type == "Feature" && !noWOF)
         d3.json("wof/"+geoID+".geojson",function(data){
@@ -278,7 +279,7 @@ var Metros = function() {
     },
     clearRequest : function() {
       this.clearMap();
-      d3.select("#map").attr("class","");
+      d3.select("#map").classed("request-mode",false);
       d3.select("#request-wrapper").attr("class","");
       d3.select("#make-request").style("display","none");
     },

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -12,7 +12,7 @@
     <h1 class="headroom text-center">metro extracts</h1>
     <p>Each week, Metro Extracts automatically extracts the latest <a href='http://openstreetmap.org/'>OpenStreetMap</a> data into manageable, metro-area files in a variety of formats for you to use. Download an existing extracts to get started right away, or request a new extract of anywhere in the world!</p>
     <p>The <span class="legend-red">red</span> boxes represent existing extracts, while the <span class="legend-blue">blue</span> ones are new requests.</p>
-    <p class="text-center">
+    <p style="margin-top: 20px;">
       <a href="https://mapzen.com/documentation/metro-extracts/">Documentation</a> |
       <a href="https://mapzen.com/documentation/metro-extracts/walkthrough/">Tutorial</a> |
       <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">File Format Guide</a>
@@ -70,6 +70,9 @@
     "{{ url_for('static', filename='scene.yaml') }}"
   );
 
+  if (document.getElementById("search_input").value.length)
+    metrosPage.onSubmit(document.getElementById("search_input").value);
+
   d3.selectAll(".country-name")
     .on("click",function(d){
       metrosPage.doSearch(d3.select(this).text(), true);
@@ -82,7 +85,7 @@
   });
 
   d3.select("#search_input").on("keyup",function(){
-    metrosPage.processKeyup(event);
+    metrosPage.processKeyup(d3.event);
   });
   
 {% endblock %}

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -34,23 +34,23 @@
 
     <h3>Downloads</h3>
     <div id="downloads">
+      <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">Points, Lines, and Polygons (OSM2PGSQL)</a>
       <div class="dl-group">
-        <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">Points, Lines, and Polygons (OSM2PGSQL)</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-shapefiles.zip">SHAPEFILE</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-geojson.zip">GEOJSON</a>
       </div>
+      <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">Layers (buildings, roads, etc) (IMPOSM)</a>
       <div class="dl-group">
-        <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">Layers (buildings, roads, etc) (IMPOSM)</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-shapefiles.zip">SHAPEFILE</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-geojson.zip">GEOJSON</a>
       </div>
+      <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">OpenStreetMap-specific Formats</a>
       <div class="dl-group">
-        <a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">OpenStreetMap-specific Formats</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.pbf">OSM PBF</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.xml">OSM XML</a>
       </div>
+      <label>Coastlines</label>
       <div class="dl-group">
-        <label>Coastlines</label>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.water.coastline.zip">WATER COASTLINE SHAPEFILE</a>
         <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.land.coastline.zip">LAND COASTLINE SHAPEFILE</a>
       </div>

--- a/App/templates/odes/extract.html
+++ b/App/templates/odes/extract.html
@@ -28,8 +28,8 @@
     </div>
     <h3>Downloads</h3>
     {% if extract.odes.status == "pending" or extract.odes.status == "processing" %}
-      <p class="error">Sit tight! Your extract will take a little while to process, depending on the size of the area that you requested.</p>
-      <p class="error">Your download links will appear on this page once it has finished processing. We will also email you a link to this page, so feel free to close this page and come back to it later!</p>
+      <p class="error">Sit tight! Your extract will take a little while to process, depending on the size of the area that you requested. This usually takes 30-60 minutes.</p>
+      <p class="error">Your download links will appear on this page once it has finished processing. We will also email you a link to this page, so feel free to close this page and come back to it later! The email will go to whichever email address is registered with your Github account.</p>
     {% elif extract.odes.status == "errored" %}
       <p class="error">Oh no, your extract request seems to have errored out. Please let us know at <a href="mailto:hello@mapzen.com">hello@mapzen.com</a>.</p>
     {% else %}


### PR DESCRIPTION
closes #109 
* disable display block for link text on metro page (unecessary click capturing)
* back button recreates state on index
* fix ff autocomplete bug
* added messaging about length of extract processing time and email address
* disable doubleclick to zoom on metro and extract pages