### PR TITLE
Skip button press with a cookie

### DIFF
--- a/App/templates/oauth/error-authenticate.html
+++ b/App/templates/oauth/error-authenticate.html
@@ -14,7 +14,7 @@
         <input type="hidden" name="state" value="{{state}}">
         <input type="hidden" name="client_id" value="{{client_id}}">
         <input type="hidden" name="redirect_uri" value="{{redirect_uri}}">
-        <input type="hidden" name="response_type" value="code">
+        <input type="hidden" name="response_type" value="{{response_type}}">
         <button class="btn btn-mapzen-alt">CONTINUE</button>
     </form>
   </div>

--- a/App/web.py
+++ b/App/web.py
@@ -10,6 +10,9 @@ def make_app(url_prefix):
     apply_blueprint(app, url_prefix)
     apply_oauth_blueprint(app, url_prefix)
     apply_odes_blueprint(app, url_prefix)
+    
+    app.config['SESSION_COOKIE_PATH'] = url_prefix
+    app.config['SESSION_COOKIE_NAME'] = 'metro-extracts-session'
 
     return app
 

--- a/test.py
+++ b/test.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse, urlencode, urlunparse, parse_qsl
 from re import compile
 import json
 
-from App import web, util, data, odes
+from App import web, util, data, odes, oauth
 from bs4 import BeautifulSoup
 from httmock import HTTMock, response
 from flask import Flask
@@ -243,7 +243,8 @@ class TestApp (unittest.TestCase):
             resp5 = self.client.get(starting_path)
             soup5 = BeautifulSoup(resp5.data, 'html.parser')
 
-            self.assertEqual(resp5.status_code, 401)
+            self.assertTrue(resp5.headers['Location'].startswith(oauth.mapzen_authorize_url))
+            self.assertEqual(resp5.status_code, 302)
     
     def test_login(self):
         '''


### PR DESCRIPTION
For any user who's already been logged-in, simply redirect to Mapzen.com instead of offering a button press.

* [x] Implement session variable for users who've been here before.
* [x] Ensure that there is no possible mapzen.com cookie contention.

Closes #165.