### PR TITLE
allow extracts to be renamed

### DIFF
--- a/App/odes.py
+++ b/App/odes.py
@@ -67,7 +67,7 @@ def get_odes_extracts(db, api_keys):
         extract = data.get_extract(db, odes=odes)
         
         if extract is None:
-            extract = data.Extract(None, None, odes, None, None, None)
+            extract = data.Extract(None, None, None, odes, None, None, None)
         
         extracts.append(extract)
 
@@ -107,7 +107,7 @@ def get_odes_extract(db, id, api_keys):
     
     if extract is None:
         # Known ODES, but nothing in the DB so make one up.
-        return data.Extract(None, None, odes, None, None, None)
+        return data.Extract(None, None, None, odes, None, None, None)
     
     return extract
 

--- a/App/odes.py
+++ b/App/odes.py
@@ -170,12 +170,13 @@ def post_envelope():
     '''
     '''
     form = request.form
+    name = form.get('display_name')
     bbox = [float(form[k]) for k in ('bbox_w', 'bbox_s', 'bbox_e', 'bbox_n')]
     wof_name, wof_id = form.get('wof_name'), form.get('wof_id') and int(form['wof_id'])
     envelope = data.Envelope(str(uuid4())[-12:], bbox)
     
     with data.connect(current_app.config['DB_DSN']) as db:
-        data.add_extract_envelope(db, envelope, data.WoF(wof_id, wof_name))
+        data.add_extract_envelope(db, name, envelope, data.WoF(wof_id, wof_name))
 
     return redirect(url_for('ODES.get_envelope', envelope_id=envelope.id), 303)
 

--- a/App/odes.py
+++ b/App/odes.py
@@ -116,7 +116,7 @@ def request_odes_extract(extract, request, url_for, api_key):
     '''
     env = Environment(loader=PackageLoader(__name__, 'templates'))
     args = dict(
-        name = extract.wof.name or 'an unnamed place',
+        name = extract.name or extract.wof.name or 'an unnamed place',
         link = urljoin(util.get_base_url(request), url_for('ODES.get_extract', extract_id=extract.id)),
         extracts_link = urljoin(util.get_base_url(request), url_for('ODES.get_extracts')),
         created = extract.created

--- a/App/static/css/metros.css
+++ b/App/static/css/metros.css
@@ -299,7 +299,11 @@ body.data-pages .inline-submit .btn:hover {
   margin-bottom: -1px;
 }
 @media (max-width: 768px) {
-  .column-map {
+  .map-wrapper {
+    position: relative;
+    width: 100%;
+  }
+  #map {
     position: relative;
   }
 }

--- a/App/static/js/metros.js
+++ b/App/static/js/metros.js
@@ -331,7 +331,7 @@ var Metros = function() {
 
       var geoID = metro.properties.id;
       d3.select("input[name='wof_id']").attr("value",geoID);
-      d3.select("input[name='wof_name']").attr("value",metro.properties.label);
+      d3.select("input[name='display_name']").attr("value",metro.properties.label);
 
       // blue box on map
       requestBoundingBox = this.calculateNewBox(bbox);

--- a/App/static/js/metros.js
+++ b/App/static/js/metros.js
@@ -331,6 +331,7 @@ var Metros = function() {
 
       var geoID = metro.properties.id;
       d3.select("input[name='wof_id']").attr("value",geoID);
+      d3.select("input[name='wof_name']").attr("value",metro.properties.label);
       d3.select("input[name='display_name']").attr("value",metro.properties.label);
 
       // blue box on map

--- a/App/static/js/metros.js
+++ b/App/static/js/metros.js
@@ -31,7 +31,8 @@ var Metros = function() {
 
       var divHeight = document.getElementById("list-wrapper").offsetHeight,
         processScroll = true;
-      window.onscroll = doThisStuffOnScroll;
+      if (window.innerWidth > 768)
+        window.onscroll = doThisStuffOnScroll;
 
       function doThisStuffOnScroll() {
         if (!processScroll) return;
@@ -64,7 +65,7 @@ var Metros = function() {
           scrollWheelZoom: false,
           scene: sceneURL,
           center: [20,0],
-          zoom: 2,
+          zoom: (window.innerWidth > 768) ? 2 : 1,
           attribution: '<a href="https://mapzen.com/tangram">Tangram</a> | <a href="http://www.openstreetmap.org/copyright">&copy; OSM contributors</a> | <a href="https://mapzen.com/">Mapzen</a>',
           fallbackTile: L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
             attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>'})

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -71,8 +71,10 @@
             <input name="bbox_e" type="hidden" />
             <input name="wof_id" type="hidden" />
             <input name="wof_name" type="hidden" />
-            <label>Your Extract Name:</label>
-            <input name="display_name" type="text" />
+            <div style="margin-bottom: 10px;">
+              <label>Your Extract Name:</label>
+              <input name="display_name" type="text" style="width:300px;" />
+            </div>
             <button class="btn btn-transparent">Get Extract</button>
           </form>
           <p class="default-request-text encompassed-text request-messaging note">(Note: Custom extracts take about 30-60 minutes to generate and you will be guided to sign in or sign up for a free Mapzen Developer account)</p>

--- a/App/templates/index.html
+++ b/App/templates/index.html
@@ -71,7 +71,9 @@
             <input name="bbox_e" type="hidden" />
             <input name="wof_id" type="hidden" />
             <input name="wof_name" type="hidden" />
-            <button class="btn btn-transparent">Get <span class="name"></span> Extract</button>
+            <label>Your Extract Name:</label>
+            <input name="display_name" type="text" />
+            <button class="btn btn-transparent">Get Extract</button>
           </form>
           <p class="default-request-text encompassed-text request-messaging note">(Note: Custom extracts take about 30-60 minutes to generate and you will be guided to sign in or sign up for a free Mapzen Developer account)</p>
           <p class="request-greater-1 request-messaging note">(Note: You have defined a large area as a custom extract. This might take a few hours to finish. You will be guided to sign in or sign up for a free Mapzen Developer account to complete this request)</p>

--- a/App/templates/odes/extract.html
+++ b/App/templates/odes/extract.html
@@ -14,7 +14,7 @@
       <li>
         <a href="{{ url_for('ODES.get_extracts') }}">Your Extracts</a>
       </li>
-      <li class="active">{{extract.wof.name or extract.id or extract.odes.id}}</li>
+      <li class="active">{{extract.name or extract.wof.name or extract.id or extract.odes.id}}</li>
     </ol>
   </div>
   <div class="col-sm-6 col-xs-12">
@@ -22,7 +22,7 @@
   </div>
   <div class="col-sm-6 col-xs-12">
     <h2>Your Extract:</h2>
-    <h2>{{extract.wof.name or extract.id or extract.odes.id}}</h2>
+    <h2>{{extract.name or extract.wof.name or extract.id or extract.odes.id}}</h2>
     <div class="btn-group" style="margin: 0 auto;">
       {% if user_id %}
         <a href="{{ url_for('ODES.get_extracts') }}">Your Custom Extracts</a> |

--- a/App/templates/odes/extracts.html
+++ b/App/templates/odes/extracts.html
@@ -28,7 +28,7 @@
       {% for extract in extracts %}
         <a class="extract" href="{{ url_for('ODES.get_extract', extract_id=(extract.id or extract.odes.id)) }}">
           <!-- <div class="map" id="map-{{extract.odes.id}}"></div> -->
-          <span class="info">{{extract.wof.name or extract.id or extract.odes.id}}</span>
+          <span class="info">{{extract.name or extract.wof.name or extract.id or extract.odes.id}}</span>
           <span class="info">{{extract.odes.status}}</span>
           <span class="info time">{{extract.odes.created_at}}</span>
         </a>

--- a/test.py
+++ b/test.py
@@ -302,7 +302,7 @@ class TestApp (unittest.TestCase):
         
         with HTTMock(response_content1):
             # POST a new envelope request
-            data1 = dict(bbox_n=37.81230, bbox_w=-122.26447, bbox_s=37.79724, bbox_e=-122.24825)
+            data1 = dict(bbox_n=37.81230, bbox_w=-122.26447, bbox_s=37.79724, bbox_e=-122.24825, display_name='woof woof')
             resp1 = self.client.post(self.prefixed('/odes/envelopes/'), data=data1)
             redirect1 = urlparse(resp1.headers.get('Location'))
             
@@ -322,6 +322,7 @@ class TestApp (unittest.TestCase):
             
             self.assertEqual(resp3.status_code, 200)
             self.assertIsNotNone(soup3.find(text=compile(r'\b37.8123')))
+            self.assertIsNotNone(soup3.find(text=compile(r'\bwoof woof\b')))
             
             # Verify that the extract is in the big list
             resp4 = self.client.get(self.prefixed('/odes/extracts/'))
@@ -329,6 +330,7 @@ class TestApp (unittest.TestCase):
             
             self.assertEqual(resp4.status_code, 200)
             self.assertIsNotNone(soup4.find(text=compile(r'\b999\b')))
+            self.assertIsNotNone(soup4.find(text=compile(r'\bwoof woof\b')))
         
         def response_content2(url, request):
             '''

--- a/test.py
+++ b/test.py
@@ -404,6 +404,7 @@ class TestApp (unittest.TestCase):
     def test_request_odes_extract(self):
     
         extract_id = str(uuid4())
+        extract_name = str(uuid4())
         wof_name = str(uuid4())
         created = datetime.now()
         extract_path = '/path/to/extracts/' + extract_id
@@ -438,7 +439,7 @@ class TestApp (unittest.TestCase):
             bbox = (-122.26447, 37.79724, -122.24825, 37.81230)
             envelope = data.Envelope(None, bbox)
             wof = data.WoF(None, wof_name)
-            extract = data.Extract(extract_id, envelope, None, None, created, wof)
+            extract = data.Extract(extract_id, extract_name, envelope, None, None, created, wof)
             o = odes.request_odes_extract(extract, request, url_for, 'odes-xxxxxxx')
         
         self.assertEqual(o.id, str(999))

--- a/test.py
+++ b/test.py
@@ -421,10 +421,10 @@ class TestApp (unittest.TestCase):
                 if url.query == 'api_key=odes-xxxxxxx':
                     body = dict(parse_qsl(request.body))
                     self.assertIn('ready', body['email_subject'])
-                    self.assertIn(wof_name, body['email_body_text'])
+                    self.assertIn(extract_name, body['email_body_text'])
                     self.assertIn(created.strftime('%b %d, %Y'), body['email_body_text'])
                     self.assertIn(extract_path, body['email_body_text'])
-                    self.assertIn(wof_name, body['email_body_html'])
+                    self.assertIn(extract_name, body['email_body_html'])
                     self.assertIn(created.strftime('%b %d, %Y'), body['email_body_html'])
                     self.assertIn(extract_path, body['email_body_html'])
                     


### PR DESCRIPTION
closes #192 

* [x] allow the name to be editable
* [x] database change for this
* [x] Keep `wof_name` field
* [x] Use new name field in emails

![screen shot 2016-07-27 at 3 00 47 pm](https://cloud.githubusercontent.com/assets/589151/17194063/fa202600-540a-11e6-93fb-50e575035b22.png)
