### PR TITLE
Add metro and extract download sizes

### DIFF
--- a/App/__init__.py
+++ b/App/__init__.py
@@ -31,6 +31,22 @@ def apply_blueprint(app, url_prefix):
     '''
     app.register_blueprint(blueprint, url_prefix=url_prefix)
 
+def populate_metro_urls(metro_id):
+    '''
+    '''
+    template = 'https://s3.amazonaws.com/metro-extracts.mapzen.com/{id}.{ext}'
+    
+    return [
+        util.Download('OSM2PGSQL SHP', uritemplate.expand(template, dict(id=metro_id, ext='osm2pgsql-shapefiles.zip')), 'SHAPEFILE'),
+        util.Download('OSM2PGSQL GEOJSON', uritemplate.expand(template, dict(id=metro_id, ext='osm2pgsql-geojson.zip')), 'GEOJSON'),
+        util.Download('IMPOSM SHP', uritemplate.expand(template, dict(id=metro_id, ext='imposm-shapefiles.zip')), 'SHAPEFILE'),
+        util.Download('IMPOSM GEOJSON', uritemplate.expand(template, dict(id=metro_id, ext='imposm-geojson.zip')), 'GEOJSON'),
+        util.Download('OSM PBF', uritemplate.expand(template, dict(id=metro_id, ext='osm.pbf')), 'OSM PBF'),
+        util.Download('OSM XML', uritemplate.expand(template, dict(id=metro_id, ext='osm.xml')), 'OSM XML'),
+        util.Download('WATER COASTLINE SHP', uritemplate.expand(template, dict(id=metro_id, ext='water.coastline.zip')), 'WATER SHAPEFILE'),
+        util.Download('LAND COASTLINE SHP', uritemplate.expand(template, dict(id=metro_id, ext='land.coastline.zip')), 'LAND SHAPEFILE'),
+        ]
+
 @blueprint.route('/')
 @util.errors_logged
 def index():

--- a/App/__init__.py
+++ b/App/__init__.py
@@ -38,20 +38,19 @@ def populate_metro_urls(metro_id):
     downloads = []
     template = 'https://s3.amazonaws.com/metro-extracts.mapzen.com/{id}.{ext}'
     
-    def _download(format, ext, label):
+    def _download(format, ext):
         url = uritemplate.expand(template, dict(id=metro_id, ext=ext))
-        downloads.append(util.Download(format, url, label))
+        downloads.append(util.Download(format, url))
     
     threads = [
-        Thread(target=_download, args=('OSM2PGSQL SHP', 'osm2pgsql-shapefiles.zip', 'SHAPEFILE')),
-        Thread(target=_download, args=('OSM2PGSQL SHP', 'osm2pgsql-shapefiles.zip', 'SHAPEFILE')),
-        Thread(target=_download, args=('OSM2PGSQL GEOJSON', 'osm2pgsql-geojson.zip', 'GEOJSON')),
-        Thread(target=_download, args=('IMPOSM SHP', 'imposm-shapefiles.zip', 'SHAPEFILE')),
-        Thread(target=_download, args=('IMPOSM GEOJSON', 'imposm-geojson.zip', 'GEOJSON')),
-        Thread(target=_download, args=('OSM PBF', 'osm.pbf', 'OSM PBF')),
-        Thread(target=_download, args=('OSM XML', 'osm.bz2', 'OSM XML')),
-        Thread(target=_download, args=('WATER COASTLINE SHP', 'water.coastline.zip', 'WATER SHAPEFILE')),
-        Thread(target=_download, args=('LAND COASTLINE SHP', 'land.coastline.zip', 'LAND SHAPEFILE')),
+        Thread(target=_download, args=('OSM2PGSQL SHP', 'osm2pgsql-shapefiles.zip')),
+        Thread(target=_download, args=('OSM2PGSQL GEOJSON', 'osm2pgsql-geojson.zip')),
+        Thread(target=_download, args=('IMPOSM SHP', 'imposm-shapefiles.zip')),
+        Thread(target=_download, args=('IMPOSM GEOJSON', 'imposm-geojson.zip')),
+        Thread(target=_download, args=('OSM PBF', 'osm.pbf')),
+        Thread(target=_download, args=('OSM XML', 'osm.bz2')),
+        Thread(target=_download, args=('WATER COASTLINE SHP', 'water.coastline.zip')),
+        Thread(target=_download, args=('LAND COASTLINE SHP', 'land.coastline.zip')),
         ]
     
     for thread in threads:

--- a/App/__init__.py
+++ b/App/__init__.py
@@ -42,7 +42,7 @@ def populate_metro_urls(metro_id):
         util.Download('IMPOSM SHP', uritemplate.expand(template, dict(id=metro_id, ext='imposm-shapefiles.zip')), 'SHAPEFILE'),
         util.Download('IMPOSM GEOJSON', uritemplate.expand(template, dict(id=metro_id, ext='imposm-geojson.zip')), 'GEOJSON'),
         util.Download('OSM PBF', uritemplate.expand(template, dict(id=metro_id, ext='osm.pbf')), 'OSM PBF'),
-        util.Download('OSM XML', uritemplate.expand(template, dict(id=metro_id, ext='osm.xml')), 'OSM XML'),
+        util.Download('OSM XML', uritemplate.expand(template, dict(id=metro_id, ext='osm.bz2')), 'OSM XML'),
         util.Download('WATER COASTLINE SHP', uritemplate.expand(template, dict(id=metro_id, ext='water.coastline.zip')), 'WATER SHAPEFILE'),
         util.Download('LAND COASTLINE SHP', uritemplate.expand(template, dict(id=metro_id, ext='land.coastline.zip')), 'LAND SHAPEFILE'),
         ]
@@ -98,9 +98,10 @@ def get_metro(metro_id, wof_id=None, wof_name=None):
     with open('cities.json') as file:
         cities = json.load(file)
         metro = {c['id']: c for c in cities}[metro_id]
+        downloads = {d.format: d for d in populate_metro_urls(metro_id)}
     
-    return render_template('metro.html', metro=metro, wof_id=wof_id,
-                           wof_name=wof_name, util=util)
+    return render_template('metro.html', metro=metro, downloads=downloads,
+                           wof_id=wof_id, wof_name=wof_name, util=util)
 
 @blueprint.route('/wof/<id>.geojson')
 @util.errors_logged

--- a/App/static/css/metro.css
+++ b/App/static/css/metro.css
@@ -24,6 +24,12 @@ p.error {
 #downloads p {
   margin-top: 15px;
 }
+#downloads .size {
+  color: #808080;
+  font-weight: normal;
+  font-size: 12px;
+  margin-left: 5px;
+}
 @media (max-width: 768px) {
   body.data-pages #map {
     height: 300px;

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -36,23 +36,23 @@
     <div id="downloads">
       <div class="label">Datasets split by geometry type: lines, points, or polygons (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">OSM2PGSQL</a>)</div>
       <div class="dl-group">
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-shapefiles.zip" data-format="OSM2PGSQL SHP">SHAPEFILE</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm2pgsql-geojson.zip" data-format="OSM2PGSQL GEOJSON">GEOJSON</a>
+        <a class="link" href="{{ downloads['OSM2PGSQL SHP'].url }}" data-format="OSM2PGSQL SHP">{{ downloads['OSM2PGSQL SHP'].label }}</a>
+        <a class="link" href="{{ downloads['OSM2PGSQL GEOJSON'].url }}" data-format="OSM2PGSQL GEOJSON">{{ downloads['OSM2PGSQL GEOJSON'].label }}</a>
       </div>
       <div class="label">Datasets grouped into individual layers by OpenStreetMap tags (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">IMPOSM</a>)</div>
       <div class="dl-group">
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-shapefiles.zip" data-format="IMPOSM SHP">SHAPEFILE</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.imposm-geojson.zip" data-format="IMPOSM GEOJSON">GEOJSON</a>
+        <a class="link" href="{{ downloads['IMPOSM SHP'].url }}" data-format="IMPOSM SHP">{{ downloads['IMPOSM SHP'].label }}</a>
+        <a class="link" href="{{ downloads['IMPOSM GEOJSON'].url }}" data-format="IMPOSM GEOJSON">{{ downloads['IMPOSM GEOJSON'].label }}</a>
       </div>
       <div class="label">Raw OpenStreetMap datasets (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">PBF and XML</a>)</div>
       <div class="dl-group">
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.pbf" data-format="OSM PBF">OSM PBF</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.osm.xml" data-format="OSM XML">OSM XML</a>
+        <a class="link" href="{{ downloads['OSM PBF'].url }}" data-format="OSM PBF">{{ downloads['OSM PBF'].label }}</a>
+        <a class="link" href="{{ downloads['OSM XML'].url }}" data-format="OSM XML">{{ downloads['OSM XML'].label }}</a>
       </div>
       <div class="label">Coastlines</div>
       <div class="dl-group">
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.water.coastline.zip" data-format="WATER COASTLINE SHP">WATER SHAPEFILE</a>
-        <a class="link" href="https://s3.amazonaws.com/metro-extracts.mapzen.com/{{ metro.id }}.land.coastline.zip" data-format="LAND COASTLINE SHP">LAND SHAPEFILE</a>
+        <a class="link" href="{{ downloads['WATER COASTLINE SHP'].url }}" data-format="WATER COASTLINE SHP">{{ downloads['WATER COASTLINE SHP'].label }}</a>
+        <a class="link" href="{{ downloads['LAND COASTLINE SHP'].url }}" data-format="LAND COASTLINE SHP">{{ downloads['LAND COASTLINE SHP'].label }}</a>
       </div>
       <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
     </div>

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -36,23 +36,23 @@
     <div id="downloads">
       <div class="label">Datasets split by geometry type: lines, points, or polygons (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">OSM2PGSQL</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['OSM2PGSQL SHP'].url }}" data-format="OSM2PGSQL SHP">{{ downloads['OSM2PGSQL SHP'].size }} {{ downloads['OSM2PGSQL SHP'].label }}</a>
-        <a class="link" href="{{ downloads['OSM2PGSQL GEOJSON'].url }}" data-format="OSM2PGSQL GEOJSON">{{ downloads['OSM2PGSQL GEOJSON'].size }} {{ downloads['OSM2PGSQL GEOJSON'].label }}</a>
+        <a class="link" href="{{ downloads['OSM2PGSQL SHP'].url }}" data-format="OSM2PGSQL SHP">{{ downloads['OSM2PGSQL SHP'].size }} SHAPEFILE</a>
+        <a class="link" href="{{ downloads['OSM2PGSQL GEOJSON'].url }}" data-format="OSM2PGSQL GEOJSON">{{ downloads['OSM2PGSQL GEOJSON'].size }} GEOJSON</a>
       </div>
       <div class="label">Datasets grouped into individual layers by OpenStreetMap tags (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">IMPOSM</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['IMPOSM SHP'].url }}" data-format="IMPOSM SHP">{{ downloads['IMPOSM SHP'].size }} {{ downloads['IMPOSM SHP'].label }}</a>
-        <a class="link" href="{{ downloads['IMPOSM GEOJSON'].url }}" data-format="IMPOSM GEOJSON">{{ downloads['IMPOSM GEOJSON'].size }} {{ downloads['IMPOSM GEOJSON'].label }}</a>
+        <a class="link" href="{{ downloads['IMPOSM SHP'].url }}" data-format="IMPOSM SHP">{{ downloads['IMPOSM SHP'].size }} SHAPEFILE</a>
+        <a class="link" href="{{ downloads['IMPOSM GEOJSON'].url }}" data-format="IMPOSM GEOJSON">{{ downloads['IMPOSM GEOJSON'].size }} GEOJSON</a>
       </div>
       <div class="label">Raw OpenStreetMap datasets (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">PBF and XML</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['OSM PBF'].url }}" data-format="OSM PBF">{{ downloads['OSM PBF'].size }} {{ downloads['OSM PBF'].label }}</a>
-        <a class="link" href="{{ downloads['OSM XML'].url }}" data-format="OSM XML">{{ downloads['OSM XML'].size }} {{ downloads['OSM XML'].label }}</a>
+        <a class="link" href="{{ downloads['OSM PBF'].url }}" data-format="OSM PBF">{{ downloads['OSM PBF'].size }} OSM PBF</a>
+        <a class="link" href="{{ downloads['OSM XML'].url }}" data-format="OSM XML">{{ downloads['OSM XML'].size }} OSM XML</a>
       </div>
       <div class="label">Coastlines</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['WATER COASTLINE SHP'].url }}" data-format="WATER COASTLINE SHP">{{ downloads['WATER COASTLINE SHP'].size }} {{ downloads['WATER COASTLINE SHP'].label }}</a>
-        <a class="link" href="{{ downloads['LAND COASTLINE SHP'].url }}" data-format="LAND COASTLINE SHP">{{ downloads['LAND COASTLINE SHP'].size }} {{ downloads['LAND COASTLINE SHP'].label }}</a>
+        <a class="link" href="{{ downloads['WATER COASTLINE SHP'].url }}" data-format="WATER COASTLINE SHP">{{ downloads['WATER COASTLINE SHP'].size }} WATER SHAPEFILE</a>
+        <a class="link" href="{{ downloads['LAND COASTLINE SHP'].url }}" data-format="LAND COASTLINE SHP">{{ downloads['LAND COASTLINE SHP'].size }} LAND SHAPEFILE</a>
       </div>
       <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
     </div>

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -36,23 +36,23 @@
     <div id="downloads">
       <div class="label">Datasets split by geometry type: lines, points, or polygons (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">OSM2PGSQL</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['OSM2PGSQL SHP'].url }}" data-format="OSM2PGSQL SHP">{{ downloads['OSM2PGSQL SHP'].size }} SHAPEFILE</a>
-        <a class="link" href="{{ downloads['OSM2PGSQL GEOJSON'].url }}" data-format="OSM2PGSQL GEOJSON">{{ downloads['OSM2PGSQL GEOJSON'].size }} GEOJSON</a>
+        <a class="link" href="{{ downloads['OSM2PGSQL SHP'].url }}" data-format="OSM2PGSQL SHP"> SHAPEFILE <span class="size">{{ downloads['OSM2PGSQL SHP'].size }}</span></a>
+        <a class="link" href="{{ downloads['OSM2PGSQL GEOJSON'].url }}" data-format="OSM2PGSQL GEOJSON">GEOJSON <span class="size">{{ downloads['OSM2PGSQL GEOJSON'].size }}</span></a>
       </div>
       <div class="label">Datasets grouped into individual layers by OpenStreetMap tags (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">IMPOSM</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['IMPOSM SHP'].url }}" data-format="IMPOSM SHP">{{ downloads['IMPOSM SHP'].size }} SHAPEFILE</a>
-        <a class="link" href="{{ downloads['IMPOSM GEOJSON'].url }}" data-format="IMPOSM GEOJSON">{{ downloads['IMPOSM GEOJSON'].size }} GEOJSON</a>
+        <a class="link" href="{{ downloads['IMPOSM SHP'].url }}" data-format="IMPOSM SHP">SHAPEFILE <span class="size">{{ downloads['IMPOSM SHP'].size }}</span></a>
+        <a class="link" href="{{ downloads['IMPOSM GEOJSON'].url }}" data-format="IMPOSM GEOJSON">GEOJSON <span class="size">{{ downloads['IMPOSM GEOJSON'].size }}</span></a>
       </div>
       <div class="label">Raw OpenStreetMap datasets (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">PBF and XML</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['OSM PBF'].url }}" data-format="OSM PBF">{{ downloads['OSM PBF'].size }} OSM PBF</a>
-        <a class="link" href="{{ downloads['OSM XML'].url }}" data-format="OSM XML">{{ downloads['OSM XML'].size }} OSM XML</a>
+        <a class="link" href="{{ downloads['OSM PBF'].url }}" data-format="OSM PBF">OSM PBF <span class="size">{{ downloads['OSM PBF'].size }}</span></a>
+        <a class="link" href="{{ downloads['OSM XML'].url }}" data-format="OSM XML">OSM XML <span class="size">{{ downloads['OSM XML'].size }}</span></a>
       </div>
       <div class="label">Coastlines</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['WATER COASTLINE SHP'].url }}" data-format="WATER COASTLINE SHP">{{ downloads['WATER COASTLINE SHP'].size }} WATER SHAPEFILE</a>
-        <a class="link" href="{{ downloads['LAND COASTLINE SHP'].url }}" data-format="LAND COASTLINE SHP">{{ downloads['LAND COASTLINE SHP'].size }} LAND SHAPEFILE</a>
+        <a class="link" href="{{ downloads['WATER COASTLINE SHP'].url }}" data-format="WATER COASTLINE SHP">WATER SHAPEFILE <span class="size">{{ downloads['WATER COASTLINE SHP'].size }}</span></a>
+        <a class="link" href="{{ downloads['LAND COASTLINE SHP'].url }}" data-format="LAND COASTLINE SHP">LAND SHAPEFILE <span class="size">{{ downloads['LAND COASTLINE SHP'].size }}</span></a>
       </div>
       <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
     </div>

--- a/App/templates/metro.html
+++ b/App/templates/metro.html
@@ -36,23 +36,23 @@
     <div id="downloads">
       <div class="label">Datasets split by geometry type: lines, points, or polygons (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">OSM2PGSQL</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['OSM2PGSQL SHP'].url }}" data-format="OSM2PGSQL SHP">{{ downloads['OSM2PGSQL SHP'].label }}</a>
-        <a class="link" href="{{ downloads['OSM2PGSQL GEOJSON'].url }}" data-format="OSM2PGSQL GEOJSON">{{ downloads['OSM2PGSQL GEOJSON'].label }}</a>
+        <a class="link" href="{{ downloads['OSM2PGSQL SHP'].url }}" data-format="OSM2PGSQL SHP">{{ downloads['OSM2PGSQL SHP'].size }} {{ downloads['OSM2PGSQL SHP'].label }}</a>
+        <a class="link" href="{{ downloads['OSM2PGSQL GEOJSON'].url }}" data-format="OSM2PGSQL GEOJSON">{{ downloads['OSM2PGSQL GEOJSON'].size }} {{ downloads['OSM2PGSQL GEOJSON'].label }}</a>
       </div>
       <div class="label">Datasets grouped into individual layers by OpenStreetMap tags (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">IMPOSM</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['IMPOSM SHP'].url }}" data-format="IMPOSM SHP">{{ downloads['IMPOSM SHP'].label }}</a>
-        <a class="link" href="{{ downloads['IMPOSM GEOJSON'].url }}" data-format="IMPOSM GEOJSON">{{ downloads['IMPOSM GEOJSON'].label }}</a>
+        <a class="link" href="{{ downloads['IMPOSM SHP'].url }}" data-format="IMPOSM SHP">{{ downloads['IMPOSM SHP'].size }} {{ downloads['IMPOSM SHP'].label }}</a>
+        <a class="link" href="{{ downloads['IMPOSM GEOJSON'].url }}" data-format="IMPOSM GEOJSON">{{ downloads['IMPOSM GEOJSON'].size }} {{ downloads['IMPOSM GEOJSON'].label }}</a>
       </div>
       <div class="label">Raw OpenStreetMap datasets (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">PBF and XML</a>)</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['OSM PBF'].url }}" data-format="OSM PBF">{{ downloads['OSM PBF'].label }}</a>
-        <a class="link" href="{{ downloads['OSM XML'].url }}" data-format="OSM XML">{{ downloads['OSM XML'].label }}</a>
+        <a class="link" href="{{ downloads['OSM PBF'].url }}" data-format="OSM PBF">{{ downloads['OSM PBF'].size }} {{ downloads['OSM PBF'].label }}</a>
+        <a class="link" href="{{ downloads['OSM XML'].url }}" data-format="OSM XML">{{ downloads['OSM XML'].size }} {{ downloads['OSM XML'].label }}</a>
       </div>
       <div class="label">Coastlines</div>
       <div class="dl-group">
-        <a class="link" href="{{ downloads['WATER COASTLINE SHP'].url }}" data-format="WATER COASTLINE SHP">{{ downloads['WATER COASTLINE SHP'].label }}</a>
-        <a class="link" href="{{ downloads['LAND COASTLINE SHP'].url }}" data-format="LAND COASTLINE SHP">{{ downloads['LAND COASTLINE SHP'].label }}</a>
+        <a class="link" href="{{ downloads['WATER COASTLINE SHP'].url }}" data-format="WATER COASTLINE SHP">{{ downloads['WATER COASTLINE SHP'].size }} {{ downloads['WATER COASTLINE SHP'].label }}</a>
+        <a class="link" href="{{ downloads['LAND COASTLINE SHP'].url }}" data-format="LAND COASTLINE SHP">{{ downloads['LAND COASTLINE SHP'].size }} {{ downloads['LAND COASTLINE SHP'].label }}</a>
       </div>
       <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
     </div>

--- a/App/templates/odes/extract.html
+++ b/App/templates/odes/extract.html
@@ -51,23 +51,23 @@
       <div id="downloads">
         <div class="label">Datasets split by geometry type: lines, points, or polygons (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">OSM2PGSQL</a>)</div>
         <div class="dl-group">
-          <a class="link" href="{{ downloads['osm2pgsql shapefiles zip'].url }}"  data-format="OSM2PGSQL SHP">{{ downloads['osm2pgsql shapefiles zip'].size }} SHAPEFILE</a>
-          <a class="link" href="{{ downloads['osm2pgsql geojson zip'].url }}"  data-format="OSM2PGSQL GEOJSON">{{ downloads['osm2pgsql geojson zip'].size }} GEOJSON</a>
+          <a class="link" href="{{ downloads['osm2pgsql shapefiles zip'].url }}"  data-format="OSM2PGSQL SHP">SHAPEFILE <span class="size">{{ downloads['osm2pgsql shapefiles zip'].size }}</span></a>
+          <a class="link" href="{{ downloads['osm2pgsql geojson zip'].url }}"  data-format="OSM2PGSQL GEOJSON">GEOJSON <span class="size">{{ downloads['osm2pgsql geojson zip'].size }}</span></a>
         </div>
         <div class="label">Datasets grouped into individual layers by OpenStreetMap tags (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">IMPOSM</a>)</div>
         <div class="dl-group">
-          <a class="link" href="{{ downloads['imposm shapefiles zip'].url }}"  data-format="IMPOSM SHP">{{ downloads['imposm shapefiles zip'].size }} SHAPEFILE</a>
-          <a class="link" href="{{ downloads['imposm geojson zip'].url }}"  data-format="IMPOSM GEOJSON">{{ downloads['imposm geojson zip'].size }} GEOJSON</a>
+          <a class="link" href="{{ downloads['imposm shapefiles zip'].url }}"  data-format="IMPOSM SHP">SHAPEFILE <span class="size">{{ downloads['imposm shapefiles zip'].size }}</span></a>
+          <a class="link" href="{{ downloads['imposm geojson zip'].url }}"  data-format="IMPOSM GEOJSON">GEOJSON <span class="size">{{ downloads['imposm geojson zip'].size }}</span></a>
         </div>
         <div class="label">Raw OpenStreetMap datasets (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">PBF and XML</a>)</div>
         <div class="dl-group">
-          <a class="link" href="{{ downloads['osm pbf'].url }}"  data-format="OSM PBF">{{ downloads['osm pbf'].size }} OSM PBF</a>
-          <a class="link" href="{{ downloads['osm bz2'].url }}"  data-format="OSM XML">{{ downloads['osm bz2'].size }} OSM XML</a>
+          <a class="link" href="{{ downloads['osm pbf'].url }}"  data-format="OSM PBF">OSM PBF <span class="size">{{ downloads['osm pbf'].size }}</span></a>
+          <a class="link" href="{{ downloads['osm bz2'].url }}"  data-format="OSM XML">OSM XML <span class="size">{{ downloads['osm bz2'].size }}</span></a>
         </div>
         <div class="label">Coastlines</div>
         <div class="dl-group">
-          <a class="link" href="{{ downloads['water coastline zip'].url }}"  data-format="WATER COASTLINE SHP">{{ downloads['water coastline zip'].size }} WATER SHAPEFILE</a>
-          <a class="link" href="{{ downloads['land coastline zip'].url }}"  data-format="LAND COASTLINE SHP">{{ downloads['land coastline zip'].size }} LAND SHAPEFILE</a>
+          <a class="link" href="{{ downloads['water coastline zip'].url }}"  data-format="WATER COASTLINE SHP">WATER SHAPEFILE <span class="size">{{ downloads['water coastline zip'].size }}</span></a>
+          <a class="link" href="{{ downloads['land coastline zip'].url }}"  data-format="LAND COASTLINE SHP">LAND SHAPEFILE <span class="size">{{ downloads['land coastline zip'].size }}</span></a>
         </div>
         <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
       </div>

--- a/App/templates/odes/extract.html
+++ b/App/templates/odes/extract.html
@@ -32,15 +32,15 @@
     {% if extract.odes.status == "pending" or extract.odes.status == "processing" %}
       <p class="error" style="margin-top:40px;">Sit tight! We will send you an email to the address associated with your GitHub account when your custom extract is ready for download.</p>
       <p class="error">Custom extracts take about 30-60 minutes to generate, depending on the size. The download links for your extract will appear on this page once it is ready.</p>
-    {% elif extract.odes.links
-        and 'osm2pgsql shapefiles zip' in extract.odes.links
-        and 'osm2pgsql geojson zip' in extract.odes.links
-        and 'imposm shapefiles zip' in extract.odes.links
-        and 'imposm geojson zip' in extract.odes.links
-        and 'osm pbf' in extract.odes.links
-        and 'osm bz2' in extract.odes.links
-        and 'water coastline zip' in extract.odes.links
-        and 'land coastline zip' in extract.odes.links %}
+    {% elif downloads
+        and 'osm2pgsql shapefiles zip' in downloads
+        and 'osm2pgsql geojson zip' in downloads
+        and 'imposm shapefiles zip' in downloads
+        and 'imposm geojson zip' in downloads
+        and 'osm pbf' in downloads
+        and 'osm bz2' in downloads
+        and 'water coastline zip' in downloads
+        and 'land coastline zip' in downloads %}
       {% if extract.wof.name and extract.wof.id %}
         <div id="encompassed" style="margin-top: 40px;">
           <p>To clip this extract to the <span class="legend-blue">{{extract.wof.name}} boundary</span>, use this outline:</p>
@@ -51,23 +51,23 @@
       <div id="downloads">
         <div class="label">Datasets split by geometry type: lines, points, or polygons (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">OSM2PGSQL</a>)</div>
         <div class="dl-group">
-          <a class="link" href="{{ extract.odes.links['osm2pgsql shapefiles zip'] }}"  data-format="OSM2PGSQL SHP">SHAPEFILE</a>
-          <a class="link" href="{{ extract.odes.links['osm2pgsql geojson zip'] }}" data-format="OSM2PGSQL GEOJSON">GEOJSON</a>
+          <a class="link" href="{{ downloads['osm2pgsql shapefiles zip'].url }}"  data-format="OSM2PGSQL SHP">{{ downloads['osm2pgsql shapefiles zip'].size }} SHAPEFILE</a>
+          <a class="link" href="{{ downloads['osm2pgsql geojson zip'].url }}"  data-format="OSM2PGSQL GEOJSON">{{ downloads['osm2pgsql geojson zip'].size }} GEOJSON</a>
         </div>
         <div class="label">Datasets grouped into individual layers by OpenStreetMap tags (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm2pgsql-and-imposm" class="label">IMPOSM</a>)</div>
         <div class="dl-group">
-          <a class="link" href="{{ extract.odes.links['imposm shapefiles zip'] }}" data-format="IMPOSM SHP">SHAPEFILE</a>
-          <a class="link" href="{{ extract.odes.links['imposm geojson zip'] }}" data-format="IMPOSM GEOJSON">GEOJSON</a>
+          <a class="link" href="{{ downloads['imposm shapefiles zip'].url }}"  data-format="IMPOSM SHP">{{ downloads['imposm shapefiles zip'].size }} SHAPEFILE</a>
+          <a class="link" href="{{ downloads['imposm geojson zip'].url }}"  data-format="IMPOSM GEOJSON">{{ downloads['imposm geojson zip'].size }} GEOJSON</a>
         </div>
         <div class="label">Raw OpenStreetMap datasets (<a href="https://mapzen.com/documentation/metro-extracts/overview/#osm-pbf-and-osm-xml" class="label">PBF and XML</a>)</div>
         <div class="dl-group">
-          <a class="link" href="{{ extract.odes.links['osm pbf'] }}" data-format="OSM PBF">OSM PBF</a>
-          <a class="link" href="{{ extract.odes.links['osm bz2'] }}" data-format="OSM XML">OSM XML</a>
+          <a class="link" href="{{ downloads['osm pbf'].url }}"  data-format="OSM PBF">{{ downloads['osm pbf'].size }} OSM PBF</a>
+          <a class="link" href="{{ downloads['osm bz2'].url }}"  data-format="OSM XML">{{ downloads['osm bz2'].size }} OSM XML</a>
         </div>
         <div class="label">Coastlines</div>
         <div class="dl-group">
-          <a class="link" href="{{ extract.odes.links['water coastline zip'] }}" data-format="WATER COASTLINE SHP">WATER SHAPEFILE</a>
-          <a class="link" href="{{ extract.odes.links['land coastline zip'] }}" data-format="LAND COASTLINE SHP">LAND SHAPEFILE</a>
+          <a class="link" href="{{ downloads['water coastline zip'].url }}"  data-format="WATER COASTLINE SHP">{{ downloads['water coastline zip'].size }} WATER SHAPEFILE</a>
+          <a class="link" href="{{ downloads['land coastline zip'].url }}"  data-format="LAND COASTLINE SHP">{{ downloads['land coastline zip'].size }} LAND SHAPEFILE</a>
         </div>
         <p>If you're unsure of which file to pick, check out our <a href="https://mapzen.com/documentation/metro-extracts/overview/#choose-a-file-format">format guide</a>.</p>
       </div>

--- a/App/util.py
+++ b/App/util.py
@@ -14,10 +14,9 @@ class KnownUnknown (Exception): pass
 
 class Download:
 
-    def __init__(self, format, url, label):
+    def __init__(self, format, url):
         self.format = format
         self.url = url
-        self.label = label
         
         resp = requests.head(url, timeout=2)
         self.size = nice_size(int(resp.headers.get('Content-Length')))

--- a/App/util.py
+++ b/App/util.py
@@ -14,11 +14,35 @@ class KnownUnknown (Exception): pass
 
 class Download:
 
-    def __init__(self, format, url, label, size=None):
+    def __init__(self, format, url, label):
         self.format = format
         self.url = url
         self.label = label
-        self.size = size
+        self.size = nice_size(int(requests.head(url).headers.get('Content-Length')))
+        
+        print(url, self.size)
+
+def nice_size(size):
+    KB = 1024.
+    MB = 1024. * KB
+    GB = 1024. * MB
+    TB = 1024. * GB
+
+    if size < KB:
+        size, suffix = size, 'B'
+    elif size < MB:
+        size, suffix = size/KB, 'KB'
+    elif size < GB:
+        size, suffix = size/MB, 'MB'
+    elif size < TB:
+        size, suffix = size/GB, 'GB'
+    else:
+        size, suffix = size/TB, 'TB'
+
+    if size < 10:
+        return '{:.1f}{}'.format(size, suffix)
+    else:
+        return '{:.0f}{}'.format(size, suffix)
 
 def errors_logged(route_function):
     '''

--- a/App/util.py
+++ b/App/util.py
@@ -18,9 +18,9 @@ class Download:
         self.format = format
         self.url = url
         self.label = label
-        self.size = nice_size(int(requests.head(url).headers.get('Content-Length')))
         
-        print(url, self.size)
+        resp = requests.head(url, timeout=2)
+        self.size = nice_size(int(resp.headers.get('Content-Length')))
 
 def nice_size(size):
     KB = 1024.

--- a/App/util.py
+++ b/App/util.py
@@ -12,6 +12,14 @@ import requests
 
 class KnownUnknown (Exception): pass
 
+class Download:
+
+    def __init__(self, format, url, label, size=None):
+        self.format = format
+        self.url = url
+        self.label = label
+        self.size = size
+
 def errors_logged(route_function):
     '''
     '''


### PR DESCRIPTION
Added download sizes to regular and custom extract pages. Closes #184.

On custom extract pages:

<img width="623" alt="screen shot 2016-08-01 at 8 09 19 pm" src="https://cloud.githubusercontent.com/assets/58730/17315845/ec35959e-5823-11e6-9067-a4f2b17ef448.png">

On regular extract pages:

<img width="619" alt="screen shot 2016-08-01 at 8 09 30 pm" src="https://cloud.githubusercontent.com/assets/58730/17315847/ef6f5484-5823-11e6-961b-2e28ef212442.png">
