### PR TITLE
adding a check for source before requesting wof outline

### DIFF
--- a/App/static/js/metros.js
+++ b/App/static/js/metros.js
@@ -341,7 +341,7 @@ var Metros = function() {
       d3.select("#map").classed("request-mode",true);
 
       // if we have WOF outline data, show this
-      if (metro.type == "Feature" && !noWOF)
+      if (!noWOF && metro.type == "Feature" && metro.properties.source == "whosonfirst")
         d3.json(wofPrefix.replace('GEOID', geoID), function(data){
           if (!data) return;
           outline = L.geoJson(data.geometry, { className : "outline" }).addTo(displayMap);


### PR DESCRIPTION
closes #207 

@migurski I believe this is sufficient?

Although, what's the point of specifying `source=wof` in the autocomplete list if we are getting results from geonames back?