### PR TITLE
showing filtered metros

### DIFF
--- a/App/static/css/metros.css
+++ b/App/static/css/metros.css
@@ -165,6 +165,9 @@ body.data-pages .inline-submit .btn:hover {
 #content-wrapper[class*="filtered"] #extracts {
   display: none;
 }
+#content-wrapper[class="filtered-encompassed"] #extracts {
+  display: block;
+}
 #extracts .country:first-child {
   margin-top: 5px;
 }


### PR DESCRIPTION
closes #220 

So, when we decided to hide the list under all typing/searches, I was a bit too far-reaching in that display:none attr. This will make sure to show that list of cities for the encompassing-metro case.