### PR TITLE
Fix for missing ODES timestamp

### DIFF
--- a/App/odes.py
+++ b/App/odes.py
@@ -60,8 +60,8 @@ def get_odes_extracts(db, api_keys):
         if resp.status_code in range(200, 299):
             odeses.extend([data.ODES(str(oj['id']), status=oj['status'], bbox=oj['bbox'],
                                      links=oj.get('download_links', {}),
-                                     processed_at=parse_datetime(oj['processed_at']),
-                                     created_at=parse_datetime(oj['created_at']))
+                                     processed_at=(parse_datetime(oj['processed_at']) if oj['processed_at'] else None),
+                                     created_at=(parse_datetime(oj['created_at']) if oj['created_at'] else None))
                            for oj in resp.json()])
     
     for odes in sorted(odeses, key=attrgetter('created_at'), reverse=True):
@@ -91,8 +91,8 @@ def get_odes_extract(db, id, api_keys):
                 oj = resp.json()
                 odes = data.ODES(str(oj['id']), status=oj['status'], bbox=oj['bbox'],
                                  links=oj.get('download_links', {}),
-                                 processed_at=parse_datetime(oj['processed_at']),
-                                 created_at=parse_datetime(oj['created_at']))
+                                 processed_at=(parse_datetime(oj['processed_at']) if oj['processed_at'] else None),
+                                 created_at=(parse_datetime(oj['created_at']) if oj['created_at'] else None))
                 break
     
         if odes is None:
@@ -143,8 +143,8 @@ def request_odes_extract(extract, request, url_for, api_key):
     
     return data.ODES(str(oj['id']), status=oj['status'], bbox=oj['bbox'],
                      links=oj.get('download_links', {}),
-                     processed_at=parse_datetime(oj['processed_at']),
-                     created_at=parse_datetime(oj['created_at']))
+                     processed_at=(parse_datetime(oj['processed_at']) if oj['processed_at'] else None),
+                     created_at=(parse_datetime(oj['created_at']) if oj['created_at'] else None))
 
 def populate_link_downloads(odes_links):
     '''

--- a/test.py
+++ b/test.py
@@ -426,12 +426,6 @@ class TestApp (unittest.TestCase):
                     data = u'''[\r  {\r    "service": "odes",\r    "key": "odes-xxxxxxx",\r    "created_at": "2015-12-15T15:24:57.236Z",\r    "nickname": "Untitled",\r    "status": "created"\r  },\r  {\r    "service": "odes",\r    "key": "odes-yyyyyyy",\r    "created_at": "2015-12-15T15:24:59.320Z",\r    "nickname": "Untitled",\r    "status": "disabled"\r  }\r]'''
                     return response(200, data.encode('utf8'), headers=response_headers)
 
-            if MHP == ('POST', 'odes.mapzen.com', '/extracts'):
-                if url.query == 'api_key=odes-xxxxxxx':
-                    bbox = dict(parse_qsl(request.body))
-                    data = u'''{\r  "error": "can't have more than 5 extracts currently processing"\r}'''
-                    return response(403, data.encode('utf8'), headers=response_headers)
-
             raise Exception(request.method, url, request.headers, request.body)
         
         with HTTMock(response_content):
@@ -442,6 +436,65 @@ class TestApp (unittest.TestCase):
             
             self.assertEqual(resp1.status_code, 303)
             self.assertTrue(redirect1.path.startswith(self.prefixed('/odes/envelopes/')))
+    
+    def test_odes_request_null_processed_time(self):
+        codes = ['let-me-in']
+        
+        self._do_login(codes)
+        
+        def response_content1(url, request):
+            '''
+            '''
+            MHP = request.method, url.hostname, url.path
+            response_headers = {'Content-Type': 'application/json; charset=utf-8'}
+
+            if MHP == ('GET', 'mapzen.com', '/developers/oauth_api/current_developer'):
+                if request.headers['Authorization'] == 'Bearer working-access-token':
+                    data = u'''{\r  "id": 631,\r  "email": "email@company.com",\r  "nickname": "user_github_handle",\r  "admin": false,\r  "keys": "https://mapzen.com/developers/oauth_api/current_developer/keys"\r}'''
+                    return response(200, data.encode('utf8'), headers=response_headers)
+
+            if MHP == ('GET', 'mapzen.com', '/developers/oauth_api/current_developer/keys'):
+                if request.headers['Authorization'] == 'Bearer working-access-token':
+                    data = u'''[\r  {\r    "service": "odes",\r    "key": "odes-xxxxxxx",\r    "created_at": "2015-12-15T15:24:57.236Z",\r    "nickname": "Untitled",\r    "status": "created"\r  },\r  {\r    "service": "odes",\r    "key": "odes-yyyyyyy",\r    "created_at": "2015-12-15T15:24:59.320Z",\r    "nickname": "Untitled",\r    "status": "disabled"\r  }\r]'''
+                    return response(200, data.encode('utf8'), headers=response_headers)
+
+            if MHP == ('GET', 'odes.mapzen.com', '/extracts'):
+                if url.query == 'api_key=odes-xxxxxxx':
+                    data = u'''[\r{\r  "id": 999,\r  "status": "created",\r  "created_at": "2016-06-02T03:29:25.233Z",\r  "processed_at": null,\r  "bbox": {\r    "e": -122.24825,\r    "n": 37.81230,\r    "s": 37.79724,\r    "w": -122.26447\r  }\r}\r]'''
+                    return response(200, data.encode('utf8'), headers=response_headers)
+
+            raise Exception(request.method, url, request.headers, request.body)
+        
+        with HTTMock(response_content1):
+            resp1 = self.client.get(self.prefixed('/odes/extracts/'))
+            self.assertEqual(resp1.status_code, 200)
+        
+        def response_content2(url, request):
+            '''
+            '''
+            MHP = request.method, url.hostname, url.path
+            response_headers = {'Content-Type': 'application/json; charset=utf-8'}
+
+            if MHP == ('GET', 'mapzen.com', '/developers/oauth_api/current_developer'):
+                if request.headers['Authorization'] == 'Bearer working-access-token':
+                    data = u'''{\r  "id": 631,\r  "email": "email@company.com",\r  "nickname": "user_github_handle",\r  "admin": false,\r  "keys": "https://mapzen.com/developers/oauth_api/current_developer/keys"\r}'''
+                    return response(200, data.encode('utf8'), headers=response_headers)
+
+            if MHP == ('GET', 'mapzen.com', '/developers/oauth_api/current_developer/keys'):
+                if request.headers['Authorization'] == 'Bearer working-access-token':
+                    data = u'''[\r  {\r    "service": "odes",\r    "key": "odes-xxxxxxx",\r    "created_at": "2015-12-15T15:24:57.236Z",\r    "nickname": "Untitled",\r    "status": "created"\r  },\r  {\r    "service": "odes",\r    "key": "odes-yyyyyyy",\r    "created_at": "2015-12-15T15:24:59.320Z",\r    "nickname": "Untitled",\r    "status": "disabled"\r  }\r]'''
+                    return response(200, data.encode('utf8'), headers=response_headers)
+
+            if MHP == ('GET', 'odes.mapzen.com', '/extracts'):
+                if url.query == 'api_key=odes-xxxxxxx':
+                    data = u'''[\r{\r  "id": 999,\r  "status": "created",\r  "created_at": "2016-06-02T03:29:25.233Z",\r  "bbox": {\r    "e": -122.24825,\r    "n": 37.81230,\r    "s": 37.79724,\r    "w": -122.26447\r  }\r}\r]'''
+                    return response(200, data.encode('utf8'), headers=response_headers)
+
+            raise Exception(request.method, url, request.headers, request.body)
+        
+        with HTTMock(response_content2):
+            resp1 = self.client.get(self.prefixed('/odes/extracts/'))
+            self.assertEqual(resp1.status_code, 200)
     
     def test_request_odes_extract(self):
     

--- a/test.py
+++ b/test.py
@@ -487,7 +487,7 @@ class TestApp (unittest.TestCase):
 
             if MHP == ('GET', 'odes.mapzen.com', '/extracts'):
                 if url.query == 'api_key=odes-xxxxxxx':
-                    data = u'''[\r{\r  "id": 999,\r  "status": "created",\r  "created_at": "2016-06-02T03:29:25.233Z",\r  "bbox": {\r    "e": -122.24825,\r    "n": 37.81230,\r    "s": 37.79724,\r    "w": -122.26447\r  }\r}\r]'''
+                    data = u'''[\r{\r  "id": 999,\r  "status": "created",\r  "created_at": "2016-06-02T03:29:25.233Z",\r  "processed_at": "",\r  "bbox": {\r    "e": -122.24825,\r    "n": 37.81230,\r    "s": 37.79724,\r    "w": -122.26447\r  }\r}\r]'''
                     return response(200, data.encode('utf8'), headers=response_headers)
 
             raise Exception(request.method, url, request.headers, request.body)


### PR DESCRIPTION
Sometime in the past seven hours, ODES API may have started returning responses with blank/missing `processed_at` values. This PR accounts for blanks, and handles them gracefully.